### PR TITLE
Add publication-api examples

### DIFF
--- a/app/content/publication-api.md
+++ b/app/content/publication-api.md
@@ -1,0 +1,121 @@
+<script src="https://accounts.google.com/gsi/client"></script>
+
+
+# Publication API with GIS
+
+!!! hint **Using Google Identity Services**
+This example page uses the Google Identity Services (GIS) OAuth Client and the SwG Publication API to retrieve user entitlements in cases where 3P cookies are blocked.
+!!!
+
+swg.js `getEntitlements` on article runtime may not function as intended when some cookies are blocked. Publishers are required to use the Publication API right after Sign In With Google, and in order to retrieve user's entitlements from Google to perform deferred account creation or logging in of linked account. The Publication API takes in two parameters: the `PublicationID` and an `ACCESS_TOKEN`.
+
+
+
+*   The `PublicationID` is defined for your publication in Publisher Center.
+*   The `ACCESS_TOKEN` is obtained using the OAuth flow, which we implement here using the GIS SDK.
+
+Note that it is critical that the [OAuth 2.0 Authorization code flow](https://www.ietf.org/rfc/rfc6749.txt) standard is implemented, as this flow provides you with a refresh token, and thereby lets you query the Publication API without having to repeatedly prompt the user for consent to get a new Access Token. In this flow, the user's consent is materialized by an Authorization code which you can swap for an Access Token and a Refresh Token (see [here ](https://developers.google.com/identity/protocols/oauth2/web-server#handlingresponse)for specific documentation).
+
+As an alternative to the GIS' SIWG button, you can use the [GIS' One Tap user experience](https://developers.google.com/identity/gsi/web/guides/features) by calling `google.accounts.id.prompt()` instead of `google.accounts.id.renderButton()`.
+
+
+## Demo: GIS Authenticate / Authorize + SwG Publication API
+
+Click on the SIWG button below to authenticate and give GTech Demo an Authorization Code that it will exchange for an Access Token in order to call the Publication API and display your GTech Demo Entitlements in the console below. If you don't have a subscription to GTech Demo, you will be seeing and empty bracket: `{}` (see [this page](https://github.com/subscriptions-project/swg-js/blob/main/docs/entitlements-flow.md#entitlement-response) for a mock entitlement response).
+
+#### Sign-in with Google button
+
+<div style="display:flex;">
+  <div id="siwgButton"></div>
+  <div id="entitlementsPlans"></div>
+  <div id="revokeButton" style="padding-left: 5px;"></div>
+  <div id="refreshButton" style="padding-left: 5px;"></div>
+  <div id="accessToken" style="padding-left: 5px;"></div>
+</div>
+
+<div id="GISOutput"></div>
+
+
+
+### Entitlements Response
+
+Access tokens periodically expire but you can [obtain new ones using the Refresh Token ](https://developers.google.com/identity/protocols/oauth2/web-server#offline)without prompting the user for permission (including when the user is not present). As a returning user, you will see above the Refresh Token which was stored. When you click again on SIWG, the corresponding Access Token is used but no new Authorization code is needed.
+
+
+# Implementation Samples
+
+While most of the logic for using the Publication API can be done client-side,
+certain aspects of the OAuth flow must be done server-side. The following code
+samples are split across the client and server, illustrating the type of logic
+that should happen at each layer.
+
+## Client-side code sample
+
+We suggest instantiatiating this flow by calling the GIS SDK's `google.accounts.oauth2.initCodeClient` function in the callback of the SIWG button.
+
+
+```html
+  <head>
+    <script>
+
+      // Exchange authorization code for access+refresh tokens
+      async function exchangeAuthCodeForTokens(authorizationCode) {
+        let url = "https://oauth2.googleapis.com/token?client_id=" + YOUR_OAUTH_CLIENT_ID + "&client_secret=" + YOUR_OAUTH_CLIENT_SECRET + "&code=" + authorizationCode + "&grant_type=authorization_code&redirect_uri=" + REDIRECT_URL
+        var requestOptions = {method: 'POST', redirect: 'follow'};
+        return fetch(url, requestOptions)
+          .then(response => response.json())
+          .catch(error => console.log('error', error));
+      }
+
+      function initGISAuthCodeClientRedirect(hint) { // GIS Authorization client
+        return google.accounts.oauth2.initCodeClient({
+          client_id: YOUR_OAUTH_CLIENT_ID,
+          scope: 'email',
+          hint: hint,
+          ux_mode: 'redirect',
+          redirect_uri: REDIRECT_URL, // Add to list of allowed redirects in Cloud Console
+          state: 'redirect_from_gis_authz_client',
+          select_account: false
+        });
+      }
+
+      // Initialise the GIS Authentication client
+      google.accounts.id.initialize({
+        client_id: YOUR_OAUTH_CLIENT_ID,
+        callback: (response) => {
+          let user_identifier = parseJwt(response.credential).sub
+          let valid_access_token_in_db = getAccessTokenFromStorage(user_identifier)
+          if (valid_access_token_in_db) { // Case 1: known user with valid token
+            queryPublicationAPI(publication_id, valid_access_token_in_db)
+              .then(entitlements => process_entitlements(entitlements))
+          } else { // Case 2: no creds, initialise the GIS Authorization client
+            let auth_client = initGISAuthCodeClientRedirect(hint=user_identifier)
+            auth_client.requestCode() // initiate a redirect flow
+          }
+        }
+      });
+
+      // google.accounts.id.prompt() // For pages without a login button, use One Tap
+      google.accounts.id.renderButton(
+        document.getElementById("siwgButton"),
+        { theme: "outline", size: "large" }  // customization attributes
+      );
+
+      // Handle redirect from OAuth endpoint
+      const urlParams = new URLSearchParams(window.location.search);
+      if (urlParams.get('state') === "redirect_from_gis_authz_client") {
+        exchangeAuthCodeForTokens(urlParams.get('code')).then(tokens => {
+          saveTokensInStorage(user_identifier, tokens.access_token, tokens.refresh_token)
+          return queryPublicationAPI(publicationId, tokens.access_token)
+        }).then(entitlements => process_entitlements(entitlements))
+      }
+
+     </script>
+  </head>
+
+  <body><div id="siwgButton" ></div></body>
+```
+
+## Server-side code sample
+
+Read the [documentation](https://developers.google.com/news/subscribe/reference/publication-api).

--- a/app/content/publication-api.md
+++ b/app/content/publication-api.md
@@ -165,4 +165,4 @@ We suggest instantiatiating this flow by calling the GIS SDK's `google.accounts.
 
 ## Server-side code sample
 
-Read the [documentation](https://developers.google.com/news/subscribe/reference/publication-api).
+Read about how to [manually check for entitlements](https://developers.google.com/news/reader-revenue/monetization/sell/check-for-entitlements) with the Publication API, and its [api documentation](https://developers.google.com/news/reader-revenue/monetization/reference/publication-api).

--- a/app/content/publication-api.md
+++ b/app/content/publication-api.md
@@ -23,15 +23,62 @@ As an alternative to the GIS' SIWG button, you can use the [GIS' One Tap user ex
 
 Click on the SIWG button below to authenticate and give GTech Demo an Authorization Code that it will exchange for an Access Token in order to call the Publication API and display your GTech Demo Entitlements in the console below. If you don't have a subscription to GTech Demo, you will be seeing and empty bracket: `{}` (see [this page](https://github.com/subscriptions-project/swg-js/blob/main/docs/entitlements-flow.md#entitlement-response) for a mock entitlement response).
 
-#### Sign-in with Google button
+#### Sign-in with Google and Interactive buttons
 
-<div style="display:flex;">
-  <div id="siwgButton"></div>
-  <div id="entitlementsPlans"></div>
-  <div id="revokeButton" style="padding-left: 5px;"></div>
-  <div id="refreshButton" style="padding-left: 5px;"></div>
-  <div id="accessToken" style="padding-left: 5px;"></div>
-</div>
+<table>
+  <thead>
+    <tr>
+      <th>
+        Button
+      </th>
+      <th>
+        Details
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr id="siwgButton">
+      <td>
+        <div class="button"></div>
+      </td>
+      <td>
+        <p>Sign-in with Google button that is personalized on repeat use.</p>
+      </td>
+    </tr>
+    <tr id="accessToken" class="hidden">
+      <td>
+        <div class="button"></div>
+      </td>
+      <td>
+        <p>Use the Publication API's <code>entitlements</code> endpoint with the logged-in user's <code>accessToken</code>.</p>
+      </td>
+    </tr>
+    <tr id="entitlementsPlans" class="hidden">
+      <td>
+        <div class="button"></div>
+      </td>
+      <td>
+        <p>Use the Publication API's <code>entitlementsPlans</code> endpoint to query the full detail of an entitlement for a logged-in user.</p>
+      </td>
+    </tr>
+    <tr id="refreshButton" class="hidden">
+      <td>
+        <div class="button"></div>
+      </td>
+      <td>
+        <p>Use the <code>refreshToken</code> to generate a new <code>accessToken<code>.</p>
+      </td>
+    </tr>
+    <tr id="revokeButton" class="hidden">
+      <td>
+        <div class="button"></div>
+      </td>
+      <td>
+        <p>Revoke the current <code>accessToken</code> and log out the current user.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 <div id="GISOutput"></div>
 

--- a/app/routes/publication-api-service-account.js
+++ b/app/routes/publication-api-service-account.js
@@ -19,6 +19,11 @@ import express from 'express';
 
 const router = express.Router();
 
+/**
+ * PublicationApi
+ * A sample class that uses the GoogleApis node.js client and a service
+ * account for interacting with the Publication API.
+ */
 class PublicationApi {
   constructor() {
     this.auth = new subscribewithgoogle.auth.GoogleAuth({
@@ -35,22 +40,24 @@ class PublicationApi {
   }
 }
 
-
-router.get('/', async (req, res) => {
+/**
+ * GET /:readerId
+ * A sample route that accepts a readerId as a url parameter, and uses
+ * a service account for querying the Publication API's 
+ * entitlementsPlans endpoint without an accesstoken.
+ */
+router.get('/:readerId', async (req, res) => {
   const api = new PublicationApi;
   const client = api.init();
 
-  console.log(client.publications.readers.entitlementsplans)
+  console.log(client.publications.readers.entitlementsplans);
 
   const plans = await client.publications.readers.entitlementsplans.get({
     name:
-        `publications/CAowqfCKCw/readers/8bd10f3a16570b3975d0e2b1a5bbd32a/entitlementsplans`
-  })
+        `publications/${process.env.PUBLICATION_ID}/readers/${req.params.readerId}/entitlementsplans`
+  });
 
-  console.log(plans)
-
-  // console.log(subscribewithgoogle)
-  res.json(plans.data)
+  res.json(plans.data);
 });
 
 export default router;

--- a/app/routes/publication-api-service-account.js
+++ b/app/routes/publication-api-service-account.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import subscribewithgoogle from '@googleapis/subscribewithgoogle';
+import express from 'express';
+
+const router = express.Router();
+
+class PublicationApi {
+  constructor() {
+    this.auth = new subscribewithgoogle.auth.GoogleAuth({
+      keyFile: process.env.GOOGLE_APPLICATION_CREDENTIALS,
+      scopes: [
+        'https://www.googleapis.com/auth/subscribewithgoogle.publications.entitlements.readonly'
+      ],
+    })
+  }
+
+  init() {
+    return new subscribewithgoogle.subscribewithgoogle(
+        {version: 'v1', auth: this.auth})
+  }
+}
+
+
+router.get('/', async (req, res) => {
+  const api = new PublicationApi;
+  const client = api.init();
+
+  console.log(client.publications.readers.entitlementsplans)
+
+  const plans = await client.publications.readers.entitlementsplans.get({
+    name:
+        `publications/CAowqfCKCw/readers/8bd10f3a16570b3975d0e2b1a5bbd32a/entitlementsplans`
+  })
+
+  console.log(plans)
+
+  // console.log(subscribewithgoogle)
+  res.json(plans.data)
+});
+
+export default router;

--- a/app/routes/publication-api.js
+++ b/app/routes/publication-api.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+
+const router = express.Router();
+const publicationId = process.env.PUBLICATION_ID;
+
+router.post('/exchange', express.json(), async (req, res) => {
+  const {code, redirect} = req.body;
+  const base = 'https://oauth2.googleapis.com'
+  const query_params = [
+    `client_id=${process.env.OAUTH_CLIENT_ID}`,
+    `client_secret=${process.env.OAUTH_CLIENT_SECRET}`,
+    `code=${code}`,
+    `redirect_uri=${redirect}`,
+    `grant_type=authorization_code`
+  ].join('&')
+
+  const url = `${base}/token?${query_params}`
+  const requestOptions = {
+    method: 'POST',
+    redirect: 'follow'
+  };
+
+  const response = await fetch(url, requestOptions)
+                       .then(response => response.json())
+                       .catch(error => console.log('error', error));
+  return res.json(response);
+});
+
+router.post('/refresh', express.json(), async (req, res) => {
+  const {refreshToken} = req.body;
+  const base = 'https://oauth2.googleapis.com'
+  const query_params = [
+    `client_id=${process.env.OAUTH_CLIENT_ID}`,
+    `client_secret=${process.env.OAUTH_CLIENT_SECRET}`,
+    `refresh_token=${refreshToken}`, `grant_type=refresh_token`
+  ].join('&')
+
+  const url = `${base}/token?${query_params}`
+  const requestOptions = {method: 'POST', redirect: 'follow'};
+
+  const response = await fetch(url, requestOptions)
+                       .then(response => response.json())
+                       .catch(error => console.log('error', error));
+  return res.json(response);
+});
+
+// https://subscribewithgoogle.googleapis.com/v1/publications/publicationId/entitlements?access_token=access_token
+// https://subscribewithgoogle.googleapis.com/v1/publications/publicationId/readers/user_id/entitlementsplans?access_token=access_token
+
+router.post('/entitlements', express.json(), async (req, res) => {
+  const {accessToken} = req.body;
+  const base = `https://subscribewithgoogle.googleapis.com/v1/publications`;
+  const endpoint = 'entitlements';
+  const params = `access_token=${accessToken}`;
+  const url = `${base}/${publicationId}/${endpoint}?${params}`;
+  const response = await fetch(url).then(r => r.json());
+  try {
+    // if ('entitlements' in response) {
+    //   response.entitlements[0].userId = '4df0faf26630a56329a137ccbfc5d464'
+    // }
+  } catch (e) {
+    console.log('no entitlements to mock a userId into')
+  }
+  return res.json(response);
+})
+
+router.post('/entitlementsplans', express.json(), async (req, res) => {
+  const {accessToken, user_id} = req.body;
+  const base = `https://subscribewithgoogle.googleapis.com/v1/publications`;
+  const endpoint = `readers/${user_id}/entitlementsplans`;
+  const params = `access_token=${accessToken}`;
+  const url = `${base}/${publicationId}/${endpoint}?${params}`;
+  console.log('entitlementsplans', url);
+  const response = await fetch(url).then(r => r.json());
+  return res.json(response);
+})
+
+export default router;

--- a/app/routes/publication-api.js
+++ b/app/routes/publication-api.js
@@ -60,9 +60,6 @@ router.post('/refresh', express.json(), async (req, res) => {
   return res.json(response);
 });
 
-// https://subscribewithgoogle.googleapis.com/v1/publications/publicationId/entitlements?access_token=access_token
-// https://subscribewithgoogle.googleapis.com/v1/publications/publicationId/readers/user_id/entitlementsplans?access_token=access_token
-
 router.post('/entitlements', express.json(), async (req, res) => {
   const {accessToken} = req.body;
   const base = `https://subscribewithgoogle.googleapis.com/v1/publications`;

--- a/lib/nav/documentation.js
+++ b/lib/nav/documentation.js
@@ -76,6 +76,15 @@ const sections = [
     }]
   },
   {
+    section: 'Receiving Entitlements from Google',
+    links: [{
+      label: 'Publication API',
+      url: '/reference/publication-api',
+      content: 'app/content/publication-api.md',
+      script: 'js/publication-api.js'
+    }]
+  },
+  {
     section: 'Content examples',
     links: [
       {

--- a/public/css/demo-layout.css
+++ b/public/css/demo-layout.css
@@ -41,6 +41,14 @@ body {
   flex-direction: column;
 }
 
+.hidden {
+  display:none;
+}
+
+table td {
+  padding: 5px;
+}
+
 .content {
   flex: 1;
 }

--- a/public/js/publication-api-buttons.js
+++ b/public/js/publication-api-buttons.js
@@ -1,0 +1,118 @@
+import {exchangeAuthCodeForTokens, exchangeRefreshTokenForTokens, queryLocalEntitlements, queryLocalEntitlementsPlans} from './publication-api-entitlements.js';
+import {getAuthzCred, revokeAuthCode, setAuthzCred} from './publication-api-storage.js';
+import {insertHighlightedJson, Loader} from './utils.js';
+
+/**
+ * renderButton
+ * Renders a GIS button
+ * @param {string} selector
+ */
+function renderButton(selector) {
+  google.accounts.id.renderButton(
+      document.querySelector(selector), {theme: 'outline', size: 'large'});
+}
+
+/**
+ * renderRefreshButton
+ * Creates a button to revoke authorization
+ * @param {string} selector
+ */
+function renderRefreshButton(selector) {
+  const refreshToken = getAuthzCred('refreshToken');
+  const button = document.createElement('button');
+  button.classList.add('btn', 'btn-primary');
+  button.onclick = async () => {
+    const loaderOutput = document.createElement('div');
+    document.querySelector('#GISOutput').append(loaderOutput);
+    const loader = new Loader(loaderOutput);
+    loader.start();
+    const tokens = await exchangeRefreshTokenForTokens(refreshToken);
+    setAuthzCred('accessToken', tokens.access_token);
+    loader.stop();
+    insertHighlightedJson('#GISOutput', tokens, 'Refresh token');
+  };
+  button.innerText = 'Refresh tokens with refreshToken';
+  document.querySelector(selector).appendChild(button);
+}
+
+/**
+ * renderFetchEntitlementsButton
+ * Creates a button to fetch entitlements manually
+ * @param {string} selector
+ */
+function renderFetchEntitlementsButton(selector) {
+  const accessToken = getAuthzCred('accessToken');
+  const button = document.createElement('button');
+  button.classList.add('btn', 'btn-primary');
+  button.onclick = async () => {
+    const loaderOutput = document.createElement('div');
+    document.querySelector('#GISOutput').append(loaderOutput);
+    const loader = new Loader(loaderOutput);
+    loader.start();
+    const entitlements = await queryLocalEntitlements(accessToken);
+
+    const readerId = entitlements.entitlements[0].readerId;
+    const entitlementsplans =
+        await queryLocalEntitlementsPlans(accessToken, readerId);
+
+    loader.stop();
+    insertHighlightedJson(
+        '#GISOutput', entitlements, 'Manually queried entitlements');
+    insertHighlightedJson(
+        '#GISOutput', entitlementsplans, 'Manually queried entitlementsplans');
+  };
+  button.innerText = 'Query entitlements with accessToken';
+  document.querySelector(selector).appendChild(button);
+}
+
+/**
+ * renderFetchEntitlementsPlansButton
+ * Creates a button to fetch entitlements manually
+ * @param {string} selector
+ */
+function renderFetchEntitlementsPlansButton(selector) {
+  const accessToken = getAuthzCred('accessToken');
+  const button = document.createElement('button');
+  button.classList.add('btn', 'btn-primary');
+  button.onclick = async () => {
+    const loaderOutput = document.createElement('div');
+    document.querySelector('#GISOutput').append(loaderOutput);
+    const loader = new Loader(loaderOutput);
+    loader.start();
+    const readerId = '4df0faf26630a56329a137ccbfc5d464';  // replace
+    const entitlements =
+        await queryLocalEntitlementsPlans(accessToken, readerId);
+    // const readerId = entitlements.entitlements[0].readerId;
+    const entitlementsplans =
+        await queryLocalEntitlementsPlans(accessToken, readerId);
+
+    loader.stop();
+    insertHighlightedJson(
+        '#GISOutput', entitlements, 'Manually queried entitlements');
+    insertHighlightedJson(
+        '#GISOutput', entitlementsplans, 'Manually queried entitlementsplans');
+  };
+  button.innerText = 'Query plan entitlements with accessToken';
+  document.querySelector(selector).appendChild(button);
+}
+
+/**
+ * renderRevokeButton
+ * Creates a button to revoke authorization
+ * @param {string} selector
+ */
+function renderRevokeButton(selector) {
+  const button = document.createElement('button');
+  button.classList.add('btn', 'btn-primary');
+  button.onclick = revokeAuthCode;
+  button.innerText = 'Revoke tokens';
+  document.querySelector(selector).appendChild(button);
+}
+
+export {
+  renderButton,
+  renderRefreshButton,
+  renderFetchEntitlementsButton,
+  renderFetchEntitlementsPlansButton,
+  renderRevokeButton
+};

--- a/public/js/publication-api-buttons.js
+++ b/public/js/publication-api-buttons.js
@@ -31,7 +31,7 @@ function renderRefreshButton(selector) {
     loader.stop();
     insertHighlightedJson('#GISOutput', tokens, 'Refresh token');
   };
-  button.innerText = 'Refresh tokens with refreshToken';
+  button.innerText = 'Refresh tokens';
   document.querySelector(selector).appendChild(button);
 }
 
@@ -50,18 +50,11 @@ function renderFetchEntitlementsButton(selector) {
     const loader = new Loader(loaderOutput);
     loader.start();
     const entitlements = await queryLocalEntitlements(accessToken);
-
-    const readerId = entitlements.entitlements[0].readerId;
-    const entitlementsplans =
-        await queryLocalEntitlementsPlans(accessToken, readerId);
-
     loader.stop();
     insertHighlightedJson(
         '#GISOutput', entitlements, 'Manually queried entitlements');
-    insertHighlightedJson(
-        '#GISOutput', entitlementsplans, 'Manually queried entitlementsplans');
   };
-  button.innerText = 'Query entitlements with accessToken';
+  button.innerText = 'Query entitlements';
   document.querySelector(selector).appendChild(button);
 }
 
@@ -79,20 +72,15 @@ function renderFetchEntitlementsPlansButton(selector) {
     document.querySelector('#GISOutput').append(loaderOutput);
     const loader = new Loader(loaderOutput);
     loader.start();
-    const readerId = '4df0faf26630a56329a137ccbfc5d464';  // replace
-    const entitlements =
-        await queryLocalEntitlementsPlans(accessToken, readerId);
-    // const readerId = entitlements.entitlements[0].readerId;
+    const entitlements = await queryLocalEntitlements(accessToken);
+    const readerId = entitlements.entitlements[0].readerId;
     const entitlementsplans =
         await queryLocalEntitlementsPlans(accessToken, readerId);
-
     loader.stop();
-    insertHighlightedJson(
-        '#GISOutput', entitlements, 'Manually queried entitlements');
     insertHighlightedJson(
         '#GISOutput', entitlementsplans, 'Manually queried entitlementsplans');
   };
-  button.innerText = 'Query plan entitlements with accessToken';
+  button.innerText = 'Query entitlement plans';
   document.querySelector(selector).appendChild(button);
 }
 

--- a/public/js/publication-api-entitlements.js
+++ b/public/js/publication-api-entitlements.js
@@ -1,0 +1,82 @@
+/**
+ * exchangeAuthCodeForTokens
+ * Exchange authorization code with access+refresh token
+ * @param {string} code
+ * @returns {{object}}
+ */
+async function exchangeAuthCodeForTokens(code) {
+  const redirect = `${location.origin}/reference/publication-api`;
+  const url = `${location.origin}/api/publication/exchange`;
+  const requestOptions = {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({code, redirect})
+  };
+
+  try {
+    const response = await fetch(url, requestOptions);
+    return await response.json();
+  } catch (e) {
+    console.log('Error fetching data', e);
+    throw e;
+  }
+}
+
+/**
+ * exchangeRefreshTokenForTokens
+ * @param {string} refreshToken
+ * @returns {{Object}} tokens
+ */
+async function exchangeRefreshTokenForTokens(refreshToken) {
+  const url = `${location.origin}/api/publication/refresh`;
+  const requestOptions = {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({refreshToken})
+  };
+
+  try {
+    const response = await fetch(url, requestOptions);
+    return await response.json();
+  } catch (e) {
+    console.log('Error fetching data', e);
+    throw e;
+  }
+}
+
+
+/**
+ * queryLocalEntitlements
+ * Queries the Publication API, but via a local endpoint
+ * @param {string} accessToken
+ * @returns {{object}}
+ */
+async function queryLocalEntitlements(accessToken) {
+  const url = `${location.origin}/api/publication/entitlements`;
+  const requestOptions = {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({accessToken})
+  };
+  const entitlements = await fetch(url, requestOptions).then(r => r.json());
+  return entitlements;
+}
+
+async function queryLocalEntitlementsPlans(accessToken, user_id) {
+  const url = `${location.origin}/api/publication/entitlementsplans`;
+  const requestOptions = {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({accessToken, user_id})
+  };
+  const entitlementsplans =
+      await fetch(url, requestOptions).then(r => r.json());
+  return entitlementsplans;
+}
+
+export {
+  exchangeAuthCodeForTokens,
+  exchangeRefreshTokenForTokens,
+  queryLocalEntitlements,
+  queryLocalEntitlementsPlans
+};

--- a/public/js/publication-api-google-client.js
+++ b/public/js/publication-api-google-client.js
@@ -13,7 +13,7 @@ const REQUESTED_SCOPES = [
 const REQUESTED_SCOPE = REQUESTED_SCOPES.join(' ');
 const REDIRECT = `${location.origin}/reference/publication-api`;
 const OAUTH_CLIENT_ID =
-    '695298810691-emkq4ltk1bmmbrhpl5n38un1cus8i5ob.apps.googleusercontent.com';
+    'process.env.OAUTH_CLIENT_ID';
 
 /**
  * initializeClient

--- a/public/js/publication-api-google-client.js
+++ b/public/js/publication-api-google-client.js
@@ -1,0 +1,82 @@
+import {getAuthzCred} from './publication-api-storage.js';
+import {parseJwt} from './utils.js';
+
+/**
+ * @fileoverview Description of this file.
+ */
+
+const REQUESTED_SCOPES = [
+  'email', 'https://www.googleapis.com/auth/userinfo.email',
+  'https://www.googleapis.com/auth/subscribewithgoogle.publications.entitlements.readonly'
+];
+
+const REQUESTED_SCOPE = REQUESTED_SCOPES.join(' ');
+const REDIRECT = `${location.origin}/reference/publication-api`;
+const OAUTH_CLIENT_ID =
+    '695298810691-emkq4ltk1bmmbrhpl5n38un1cus8i5ob.apps.googleusercontent.com';
+
+/**
+ * initializeClient
+ * Initializes a GIS authentication client
+ */
+function initializeClient() {
+  // Initialise the GIS Authentication client
+  google.accounts.id.initialize(
+      {client_id: OAUTH_CLIENT_ID, callback: handleClientInitialization});
+}
+
+/**
+ * initGISAuthCodeClientRedirect
+ * GIS Authorization client
+ * Create a GIS client
+ * @param {string} hint
+ * @returns {{object}}
+ */
+function initGISAuthCodeClientRedirect(hint) {
+  console.log('Redirect from initGISAuthCodeClientRedirect');
+  return google.accounts.oauth2.initCodeClient({
+    client_id: OAUTH_CLIENT_ID,
+    scope: REQUESTED_SCOPE,
+    hint: hint,
+    ux_mode: 'redirect',
+    redirect_uri: REDIRECT,
+    state: 'redirect_from_gis_authz_client',
+    select_account: false
+  });
+}
+
+/**
+ * handleClientInitialization
+ * @param {{Object}} response
+ * Handles the response from the google.accounts.id.initialize method
+ */
+async function handleClientInitialization(response) {
+  let parsedJwt = parseJwt(response.credential);
+  let authorizationCode = getAuthzCred('authorizationCode');
+
+  if (authorizationCode != null) {  // query directly the publication api
+    console.log('AuthorizationCode found for this user in our systems.');
+    // ensure it is still valid; refresh it otherwise
+    const accessToken = getAuthzCred('accessToken');
+    const refreshToken = getAuthzCred('refreshToken');
+    console.log('Data from localStorage via initializeClient()');
+    console.log({accessToken, refreshToken});
+
+    // display to user
+    insertHighlightedJson(
+        '#GISOutput', getAuthzCred('refreshToken'), 'Refresh token');
+
+    const entitlements = await queryLocalEntitlements(accessToken);
+
+    console.log({entitlements});
+    insertHighlightedJson(
+        '#GISOutput', entitlements,
+        'Entitlements after using the Sign-in with Google button');
+  } else {  // redirect
+    console.log('No authorizationCode found for this user in our systems.');
+    let auth_client = initGISAuthCodeClientRedirect(parsedJwt.sub);
+    auth_client.requestCode();
+  }
+}
+
+export {initializeClient};

--- a/public/js/publication-api-handlers.js
+++ b/public/js/publication-api-handlers.js
@@ -32,7 +32,6 @@ async function handleCachedCredentials() {
   insertHighlightedJson(
       '#GISOutput', entitlements, 'Entitlements from cached credentials');
 
-  document.querySelector('#revokeButton').classList.add('displayed');
 }
 
 export {handleRedirectFromOAuth, handleCachedCredentials};

--- a/public/js/publication-api-handlers.js
+++ b/public/js/publication-api-handlers.js
@@ -1,0 +1,38 @@
+import {exchangeAuthCodeForTokens, queryLocalEntitlements} from './publication-api-entitlements.js';
+import {getAuthzCred, setAuthzCreds} from './publication-api-storage.js';
+import {insertHighlightedJson, redirect} from './utils.js';
+
+/**
+ * handleRedirectFromOAuth
+ * @param {string} authorization_code
+ */
+async function handleRedirectFromOAuth(authorization_code) {
+  console.log('Redirect from OAuth endpoint');
+
+  // obtain, store access token, display results
+  const tokens = await exchangeAuthCodeForTokens(authorization_code);
+
+  console.log({tokens, authorization_code});
+
+  // store it all
+  setAuthzCreds(authorization_code, tokens.access_token, tokens.refresh_token);
+  redirect(
+      'state === redirect_from_gis_authz_client',
+      `${location.origin}/reference/publication-api`);
+}
+
+/**
+ * handleCachedCredentials
+ */
+async function handleCachedCredentials() {
+  console.log(getAuthzCred('refreshToken'));
+  const entitlements =
+      await queryLocalEntitlements(getAuthzCred('accessToken'));
+
+  insertHighlightedJson(
+      '#GISOutput', entitlements, 'Entitlements from cached credentials');
+
+  document.querySelector('#revokeButton').classList.add('displayed');
+}
+
+export {handleRedirectFromOAuth, handleCachedCredentials};

--- a/public/js/publication-api-storage.js
+++ b/public/js/publication-api-storage.js
@@ -1,0 +1,122 @@
+import {redirect} from './utils.js';
+
+
+/**
+ * getAuthzCreds
+ * Get authorization information in localStorage
+ * @returns {{Object}}
+ */
+function getAuthzCreds() {
+  try {
+    return {
+      authorizationCode: localStorage.getItem('authorizationCode'),
+      accessToken: localStorage.getItem('accessToken'),
+      refreshToken: localStorage.getItem('refreshToken')
+    };
+  } catch (e) {
+    console.log('Error fetching data from localStorage', e);
+    return {};
+  }
+}
+
+/**
+ * getAuthzCred
+ * Get authorization information in localStorage for a field
+ * @param {string} field
+ * @returns {string}
+ */
+function getAuthzCred(field) {
+  try {
+    return localStorage.getItem(field);
+  } catch (e) {
+    console.log(`Error fetching data from localStorage for ${field}`, e);
+    return undefined;
+  }
+}
+
+/**
+ * hasAuthzCred
+ * Test for authorization information in localStorage for a field
+ * @param {string} field
+ * @returns {boolean}
+ */
+function hasAuthzCred(field) {
+  try {
+    const data = localStorage.getItem(field);
+
+    return data && data !== '' && data !== undefined && data !== null;
+  } catch (e) {
+    console.log('Error fetching data from localStorage', e);
+    return false;
+  }
+}
+
+/**
+ * setAuthzCreds
+ * Stores authorization information in localStorage
+ * @param {string} authorizationCode
+ * @param {string} accessToken
+ * @param {string} refreshToken
+ */
+function setAuthzCreds(authorizationCode, accessToken, refreshToken) {
+  console.log(
+      'setting localStorage with',
+      {authorizationCode, accessToken, refreshToken});
+  localStorage.setItem('authorizationCode', authorizationCode);
+  localStorage.setItem('accessToken', accessToken);
+  localStorage.setItem('refreshToken', refreshToken);
+}
+
+/**
+ * setAuthzCred
+ * Stores authorization information in localStorage for a field
+ * @param {string} field
+ * @param {string} value
+ */
+function setAuthzCred(field, value) {
+  console.log('setting localStorage with', {field, value});
+  localStorage.setItem(field, value);
+}
+
+/**
+ * removeAuthZCreds
+ * Removes authorization information from localStorage
+ */
+function removeAuthZCreds() {
+  localStorage.removeItem('authorizationCode');
+  localStorage.removeItem('accessToken');
+  localStorage.removeItem('refreshToken');
+}
+
+/**
+ * removeAuthZCred
+ * Removes authorization information from localStorage for a field
+ * @param {string} field
+ */
+function removeAuthZCred(field) {
+  localStorage.removeItem(field);
+}
+
+/**
+ * revokeAuthCode
+ * Revokes authorization
+ */
+function revokeAuthCode() {
+  const destination = `${location.origin}/reference/publication-api`;
+  console.log('Revoking Code/Token');
+  google.accounts.oauth2.revoke(getAuthzCred('refreshToken'), done => {
+    console.log(done.error);
+  });
+  removeAuthZCreds();
+  redirect('revokeAuthCode', destination);
+}
+
+export {
+  setAuthzCreds,
+  setAuthzCred,
+  removeAuthZCreds,
+  revokeAuthCode,
+  getAuthzCreds,
+  getAuthzCred,
+  hasAuthzCred
+};

--- a/public/js/publication-api.js
+++ b/public/js/publication-api.js
@@ -5,11 +5,14 @@ import {hasAuthzCred} from './publication-api-storage.js';
 
 document.addEventListener('DOMContentLoaded', async function() {
   initializeClient();
-  renderButton('#siwgButton');
+  renderButton('#siwgButton .button');
   if (hasAuthzCred('accessToken')) {
-    renderFetchEntitlementsPlansButton('#entitlementsPlans');
-    renderRevokeButton('#revokeButton');
-    renderFetchEntitlementsButton('#accessToken');
+    renderFetchEntitlementsPlansButton('#entitlementsPlans .button');
+    document.querySelector('#entitlementsPlans').classList.remove('hidden');
+    renderRevokeButton('#revokeButton .button');
+    document.querySelector('#revokeButton').classList.remove('hidden');
+    renderFetchEntitlementsButton('#accessToken .button');
+    document.querySelector('#accessToken').classList.remove('hidden');
   }
 
   // handle redirect
@@ -21,6 +24,7 @@ document.addEventListener('DOMContentLoaded', async function() {
 
   if (hasAuthzCred('refreshToken')) {
     handleCachedCredentials();
-    renderRefreshButton('#refreshButton');
+    renderRefreshButton('#refreshButton .button');
+    document.querySelector('#refreshButton').classList.remove('hidden');
   }
 });

--- a/public/js/publication-api.js
+++ b/public/js/publication-api.js
@@ -1,0 +1,26 @@
+import {renderButton, renderFetchEntitlementsButton, renderFetchEntitlementsPlansButton, renderRefreshButton, renderRevokeButton} from './publication-api-buttons.js';
+import {initializeClient} from './publication-api-google-client.js';
+import {handleCachedCredentials, handleRedirectFromOAuth} from './publication-api-handlers.js';
+import {hasAuthzCred} from './publication-api-storage.js';
+
+document.addEventListener('DOMContentLoaded', async function() {
+  initializeClient();
+  renderButton('#siwgButton');
+  if (hasAuthzCred('accessToken')) {
+    renderFetchEntitlementsPlansButton('#entitlementsPlans');
+    renderRevokeButton('#revokeButton');
+    renderFetchEntitlementsButton('#accessToken');
+  }
+
+  // handle redirect
+  const urlParams = new URLSearchParams(window.location.search);
+
+  if (urlParams.get('state') === 'redirect_from_gis_authz_client') {
+    handleRedirectFromOAuth(urlParams.get('code'));
+  }
+
+  if (hasAuthzCred('refreshToken')) {
+    handleCachedCredentials();
+    renderRefreshButton('#refreshButton');
+  }
+});

--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ import readme from './app/routes/readme.js';
 
 //APIs for content sections
 import subscriptionLinkingApi from './app/routes/subscription-linking/api.js'
-
+import publicationApi from './app/routes/publication-api.js'
 
 // Proxy handles https and reverse proxy settings for running locally
 import proxy from './middleware/proxy.js';
@@ -38,6 +38,7 @@ app.use(proxy);
 app.use(ssl);
 app.use(overrides);
 
+// Mount APIs for content sections
 app.use('/readme', readme);
 app.use('/', readerRevenue);
 
@@ -59,6 +60,9 @@ app.get('/css/*', async (req, res)=>{
     res.status(500).end(`Error: failed to render ${req.path}`);
   }
 })
+
+app.use('/api/subscription-linking', subscriptionLinkingApi)
+app.use('/api/publication', publicationApi)
 
 // Boot the server
 console.log(


### PR DESCRIPTION
This PR adds the Publication APi section to the docs. This includes:

- client-side examples in `public/js/publication-api.js` and the `publication-api-*.js` supporting files.
- a server-side example for use with access tokens in `app/routes/publication-api.js`
- a server-side example for use with service accounts in `app/routes/publication-api-service-account.js`

Bug fixes:
- Adds `ENV_NAME` as an environmental variable for use in html templates, to distinguish one deployed instance from another