### PR TITLE
Feature/rewrite static files

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ templated methods.
 # General node.js env vars
 PORT=8080 #port to run on
 NODE_ENV=development
+ENV_NAME=local #Give your instance a distinct name that surfaces in the header
 
 # Settings for configuring behind a reverse proxy
 PROXY_URL=local.domain

--- a/app/routes/documentation.js
+++ b/app/routes/documentation.js
@@ -21,7 +21,7 @@ import {renderHtml, renderMarkdown} from '../../lib/renderers.js';
 
 const router = express.Router();
 
-router.use(express.static('./public'));
+// router.use(express.static('./public'));
 
 /*
   bootstrap routes from the nav

--- a/app/views/layouts/demo-layout.html
+++ b/app/views/layouts/demo-layout.html
@@ -68,7 +68,7 @@
     <button class="navbar-toggler side-menu">
       <span class="material-icons">menu</span>
     </button>
-    <a class="navbar-brand" href="/">Reader Revenue Manager: Demo</a>
+    <a class="navbar-brand" href="/">Reader Revenue Manager: Demo{{#data.env.ENV_NAME}} - {{this}}{{/data.env.ENV_NAME}}</a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#basic-example-nav"
       aria-controls="basic-example-nav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="material-icons">arrow_drop_down</span>

--- a/lib/renderers.js
+++ b/lib/renderers.js
@@ -30,9 +30,9 @@ import hljs from 'highlight.js';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 function safeEnvVars() {
-  const {GOOGLE_SITE_VERIFICATION, OAUTH_CLIENT_ID, PUBLICATION_ID} =
+  const {GOOGLE_SITE_VERIFICATION, OAUTH_CLIENT_ID, PUBLICATION_ID, ENV_NAME} =
       process.env;
-  return {GOOGLE_SITE_VERIFICATION, OAUTH_CLIENT_ID, PUBLICATION_ID};
+  return {GOOGLE_SITE_VERIFICATION, OAUTH_CLIENT_ID, PUBLICATION_ID, ENV_NAME};
 }
 
 marked.use({

--- a/lib/renderers.js
+++ b/lib/renderers.js
@@ -110,4 +110,25 @@ async function renderHtml(filePath, template, data) {
   }
 }
 
-export {renderMarkdown, renderHtml};
+async function renderStaticFile(filePath, data) {
+  try {
+    // propagate safe env vars to templates
+    data.env = safeEnvVars();
+    const staticFile = await readFile(filePath).then((buf) => buf.toString());
+
+    //find/replace for only process.env.*
+    const pattern = /\bprocess\.env\.([^\s]+)\b/g;
+    const replacedStaticFile = staticFile.replace(pattern, (match, paramName) => {
+      const value = data.env[paramName];
+      return value ? value : match; // Keep original if not found
+    });
+  
+    return replacedStaticFile
+
+  } catch (e) {
+    console.log(e);
+    throw new Error("Static file wasn't parseable", e);
+  }
+}
+
+export {renderMarkdown, renderHtml, renderStaticFile};

--- a/public/js/test.js
+++ b/public/js/test.js
@@ -19,3 +19,5 @@
  */
 
 console.log('hello, script tag in the nav...');
+
+//Current env: process.env.ENV_NAME

--- a/server.js
+++ b/server.js
@@ -28,6 +28,9 @@ import proxy from './middleware/proxy.js';
 import ssl from './middleware/ssl.js';
 import overrides from './middleware/overrides.js'
 
+//test
+import { renderStaticFile } from './lib/renderers.js';
+
 // Configure app globals
 const app = express();
 app.set('trust proxy', 'loopback');
@@ -37,6 +40,18 @@ app.use(overrides);
 
 app.use('/readme', readme);
 app.use('/', readerRevenue);
+
+app.get('/js/*', async (req, res)=>{
+  console.log(req.path)
+  const renderedStaticFile = await renderStaticFile(`public/${req.path}`, {"test":true} )
+  res.set('Content-Type','text/javascript').end(renderedStaticFile)
+})
+
+app.get('/css/*', async (req, res)=>{
+  const renderedStaticFile = await renderStaticFile(`public/${req.path}`, {"test":true} )
+  res.set('Content-Type','text/css').end(renderedStaticFile)
+})
+
 // Boot the server
 console.log(
   `Booted at ${new Date().toUTCString()} at ${process.env.HOST}:${


### PR DESCRIPTION
This PR allows for client-side static files to be able to use env vars. Existing server-side templates can already use dynamic data, as they're rendered by `express-handlebars`, but client-side static files cannot easily use the same method. To solve for this, a few changes have been made:

1. Add a new renderer, `staticFileRenderer` to `lib/renderers.js`.
2. Disable express's standard way of serving static files, and instead add dynamic routes in `server.js` to pre-process these requests.
3. Add `ENV_NAME` as a new safe environmental variable, and use it in test sample `js/test.js` file.

The `staticFileRenderer` looks at existing static files (in this case, `css` and `js` files), and looks for a `process.env.*` string. If found, it attempts to replace it with a value from the `safeEnvVars()` function, which surfaces only allowlisted environmental variables.