### PR TITLE
Feature/pub sub

### DIFF
--- a/app/content/pub-sub.md
+++ b/app/content/pub-sub.md
@@ -1,0 +1,13 @@
+# pub/sub sample page
+
+# Test Events
+
+## Play test notification
+
+<div id="testNotifications">
+</div>
+
+# Notifications
+<div id="notificationsLog">
+</div>
+## Recent Notifications

--- a/app/content/pub-sub.md
+++ b/app/content/pub-sub.md
@@ -1,13 +1,31 @@
-# pub/sub sample page
+# Pub/Sub Logging
 
-# Test Events
+This page helps debug pub/sub notifications. To configure and use this, you must create a cloud datastore in your GCP project for this instance of the app.
 
-## Play test notification
+## Steps to configure Cloud Datastore
 
-<div id="testNotifications">
-</div>
+1. Specify the region your app will run in your environmental variable `.env` file or configuration  (e.g. `us-east1`).
+2. Create a Cloud Datastore database in [GCP](https://console.cloud.google.com/datastore/databases). 
 
-# Notifications
+!!! caution **Choose `Datastore mode` as the database type**
+Datastore can run in multiple modes in GCP. This sample pub/sub logger is designed to work with Cloud Datastore's "Datastore" mode rather than the "Native" mode. While there are [many differences between the two modes](https://cloud.google.com/datastore/docs/firestore-or-datastore#in_datastore_mode), **this project uses Firestore in Datastore mode**.
+!!!
+
+3. [Deploy your copy of this application to AppEngine](https://cloud.google.com/appengine/docs/standard/nodejs/building-app/deploying-web-service). Since Cloud Pub/Sub can only hit public endpoints with data, you must have a publicly available app to receive the notifications and log them to Cloud Datastore. 
+
+4. Configure a Pub/Sub topic and Subscription. 
+    1. Please refer to the [devsite article on on handling Cloud Pub/Sub](https://developers.google.com/news/reader-revenue/monetization/sell/handle-pub-sub) for information oncreating a topic.
+    2. When creating the subscription, configure it as a [Push Subscription](https://cloud.google.com/pubsub/docs/create-push-subscription#create_a_push_subscription), and set the **Endpoint URL** to `<Your-AppEngine-Url>.appspot.com/api/pub-sub/receive`.
+
+After completing these steps, every time a notification is sent to the configured topic, the subscription will pick it up and push it to your application. The application then displays and stores it for future analysis. 
+
+!!! hint **Real world usage**
+There are many types of notifications that the configured topic will receive from Reader Revenue Manager: Enterprise. In a production environment, each type of notification would result in a different type of action (e.g. account creation, entitlement updates). This example serves only as a utility for easily viewing and debugging all pub/sub notifications.
+!!!
+
+## Notifications Log
+
+This console displays all pub/sub notifications that your application processes and stores in Cloud Datastore. It polls this application's `/api/pub-sub/received` endpoint every second, and displays the new messages as they come in. 
+
 <div id="notificationsLog">
 </div>
-## Recent Notifications

--- a/app/content/pub-sub.md
+++ b/app/content/pub-sub.md
@@ -4,7 +4,7 @@ This page helps debug pub/sub notifications. To configure and use this, you must
 
 ## Steps to configure Cloud Datastore
 
-1. Specify the region your app will run in your environmental variable `.env` file or configuration  (e.g. `us-east1`).
+1. Specify the [region](https://cloud.google.com/about/locations#regions) your app will run in your environmental variable `.env` file or configuration  (e.g. `us-east1`).
 2. Create a Cloud Datastore database in [GCP](https://console.cloud.google.com/datastore/databases). 
 
 !!! caution **Choose `Datastore mode` as the database type**

--- a/app/routes/pub-sub.js
+++ b/app/routes/pub-sub.js
@@ -30,6 +30,7 @@ router.post('/receive', express.json(), async (req, res) => {
 })
 
 router.get('/received', async (req, res) => {
+  // Read all messages stored in the `message` index
   const messages = await storage.read('message');
   return res.json(messages);
 })

--- a/app/routes/pub-sub.js
+++ b/app/routes/pub-sub.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {PubSub} from '@google-cloud/pubsub';
+import express from 'express';
+
+import {Storage} from '../../lib/datastore.js';
+
+const router = express.Router();
+const publicationId = process.env.PUBLICATION_ID;
+const topic = '';
+
+
+// // Creates a client; cache this for further use
+// const pubSubClient = new PubSub();
+
+// function listenForMessages(subscriptionNameOrId, timeout) {
+//   // References an existing subscription
+//   const subscription = pubSubClient.subscription(subscriptionNameOrId);
+
+//   // Create an event handler to handle messages
+//   let messageCount = 0;
+//   const messageHandler = message => {
+//     console.log(`Received message ${message.id}:`);
+//     console.log(`\tData: ${message.data}`);
+//     console.log(`\tAttributes: ${message.attributes}`);
+//     messageCount += 1;
+
+//     // "Ack" (acknowledge receipt of) the message
+//     message.ack();
+//   };
+
+//   // Listen for new messages until timeout is hit
+//   subscription.on('message', messageHandler);
+
+//   // Wait a while for the subscription to run. (Part of the sample only.)
+//   setTimeout(() => {
+//     subscription.removeListener('message', messageHandler);
+//     console.log(`${messageCount} message(s) received.`);
+//   }, timeout * 1000);
+// }
+
+// listenForMessages();
+
+
+router.get('/', (req, res) => {res.end('pub/sub is a-ok')})
+
+
+const storage = new Storage('pub-sub');
+router.post('/receive', express.json(), async (req, res) => {
+  // The message is a unicode string encoded in base64.
+  const message =
+      Buffer.from(req.body.message.data, 'base64').toString('utf-8');
+  await storage.create('message', message);
+  return res.status(200).end();
+})
+
+router.get('/received', async (req, res) => {
+  const messages = await storage.read('message');
+  return res.json(messages);
+})
+
+
+export default router;

--- a/app/routes/pub-sub.js
+++ b/app/routes/pub-sub.js
@@ -21,7 +21,7 @@ const router = express.Router();
 
 const storage = new Storage('pub-sub');
 router.post('/receive', express.json(), async (req, res) => {
-  // The message is a unicode string encoded in base64.
+  // The message from the Pub/Sub notification is a unicode string encoded in base64.
   const message =
       Buffer.from(req.body.message.data, 'base64').toString('utf-8');
   await storage.create('message', message);

--- a/app/routes/pub-sub.js
+++ b/app/routes/pub-sub.js
@@ -24,6 +24,7 @@ router.post('/receive', express.json(), async (req, res) => {
   // The message from the Pub/Sub notification is a unicode string encoded in base64.
   const message =
       Buffer.from(req.body.message.data, 'base64').toString('utf-8');
+  // Add the message from the Pub/Sub notification to the datastore in the `message` index
   await storage.create('message', message);
   return res.status(200).end();
 })

--- a/app/routes/pub-sub.js
+++ b/app/routes/pub-sub.js
@@ -14,50 +14,10 @@
  * limitations under the License.
  */
 
-import {PubSub} from '@google-cloud/pubsub';
 import express from 'express';
-
 import {Storage} from '../../lib/datastore.js';
 
 const router = express.Router();
-const publicationId = process.env.PUBLICATION_ID;
-const topic = '';
-
-
-// // Creates a client; cache this for further use
-// const pubSubClient = new PubSub();
-
-// function listenForMessages(subscriptionNameOrId, timeout) {
-//   // References an existing subscription
-//   const subscription = pubSubClient.subscription(subscriptionNameOrId);
-
-//   // Create an event handler to handle messages
-//   let messageCount = 0;
-//   const messageHandler = message => {
-//     console.log(`Received message ${message.id}:`);
-//     console.log(`\tData: ${message.data}`);
-//     console.log(`\tAttributes: ${message.attributes}`);
-//     messageCount += 1;
-
-//     // "Ack" (acknowledge receipt of) the message
-//     message.ack();
-//   };
-
-//   // Listen for new messages until timeout is hit
-//   subscription.on('message', messageHandler);
-
-//   // Wait a while for the subscription to run. (Part of the sample only.)
-//   setTimeout(() => {
-//     subscription.removeListener('message', messageHandler);
-//     console.log(`${messageCount} message(s) received.`);
-//   }, timeout * 1000);
-// }
-
-// listenForMessages();
-
-
-router.get('/', (req, res) => {res.end('pub/sub is a-ok')})
-
 
 const storage = new Storage('pub-sub');
 router.post('/receive', express.json(), async (req, res) => {
@@ -72,6 +32,5 @@ router.get('/received', async (req, res) => {
   const messages = await storage.read('message');
   return res.json(messages);
 })
-
 
 export default router;

--- a/lib/nav/documentation.js
+++ b/lib/nav/documentation.js
@@ -82,6 +82,12 @@ const sections = [
       url: '/reference/publication-api',
       content: 'app/content/publication-api.md',
       script: 'js/publication-api.js'
+    },
+    {
+      label: 'Pub/Sub - Handling messages',
+      url: '/pub-sub/handling',
+      content: 'app/content/pub-sub.md',
+      script: 'js/pub-sub.js'
     }]
   },
   {

--- a/public/js/pub-sub.js
+++ b/public/js/pub-sub.js
@@ -1,5 +1,7 @@
 /**
- * @fileoverview Description of this file.
+ * @fileoverview This client-side js file is used to 
+ * poll and display received notifications issued from
+ * Cloud Pub/Sub, and stored in Cloud Datastore.
  */
 import {insertHighlightedJson, Loader} from './utils.js';
 

--- a/public/js/pub-sub.js
+++ b/public/js/pub-sub.js
@@ -3,47 +3,26 @@
  */
 import {insertHighlightedJson, Loader} from './utils.js';
 
-console.log('pub-sub');
 
 async function pollNotifications() {
-  return await fetch('/api/pub-sub/received').then(r => r.json())
+  return await fetch('/api/pub-sub/received').then(r => r.json());
 }
 
 function scheduleNotifications() {
   let currentNotifications = '';
-  const id = '#testNotifications';
-  const container = document.querySelector('.devsite-content-details');
-  const output = document.getElementById('testNotifications');
+  const output = '#notificationsLog';
+  insertHighlightedJson(output, []);
 
   setInterval(async () => {
     const notifications = await pollNotifications();
     if (JSON.stringify(notifications) != currentNotifications) {
       console.log('new pub/sub messages, re-displaying');
-      container.removeChild(output.nextSibling);
-      insertHighlightedJson('#testNotifications', notifications);
+      insertHighlightedJson(output, notifications);
       currentNotifications = JSON.stringify(notifications);
     }
   }, 1000)
 }
 
-
-async function sendNotification() {
-  const body = {
-    'data': '{message: \'Test notification from reader-revenue-demo\'}',
-    'created': Date.now(),
-    'namespace': 'pub-sub',
-    'type': 'message'
-  }
-
-  await fetch('/api/pub-sub/receive', {method: 'POST', body})
-}
-
-
 document.addEventListener('DOMContentLoaded', async function() {
   await scheduleNotifications();
-
-  // document.querySelector('#testNotifications').addEventListener('click', ()
-  // => {
-  //   sendNotification();
-  // })
 });

--- a/public/js/pub-sub.js
+++ b/public/js/pub-sub.js
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview Description of this file.
+ */
+import {insertHighlightedJson, Loader} from './utils.js';
+
+console.log('pub-sub');
+
+async function pollNotifications() {
+  return await fetch('/api/pub-sub/received').then(r => r.json())
+}
+
+function scheduleNotifications() {
+  let currentNotifications = '';
+  const id = '#testNotifications';
+  const container = document.querySelector('.devsite-content-details');
+  const output = document.getElementById('testNotifications');
+
+  setInterval(async () => {
+    const notifications = await pollNotifications();
+    if (JSON.stringify(notifications) != currentNotifications) {
+      console.log('new pub/sub messages, re-displaying');
+      container.removeChild(output.nextSibling);
+      insertHighlightedJson('#testNotifications', notifications);
+      currentNotifications = JSON.stringify(notifications);
+    }
+  }, 1000)
+}
+
+
+async function sendNotification() {
+  const body = {
+    'data': '{message: \'Test notification from reader-revenue-demo\'}',
+    'created': Date.now(),
+    'namespace': 'pub-sub',
+    'type': 'message'
+  }
+
+  await fetch('/api/pub-sub/receive', {method: 'POST', body})
+}
+
+
+document.addEventListener('DOMContentLoaded', async function() {
+  await scheduleNotifications();
+
+  // document.querySelector('#testNotifications').addEventListener('click', ()
+  // => {
+  //   sendNotification();
+  // })
+});

--- a/server.js
+++ b/server.js
@@ -20,9 +20,9 @@ import readerRevenue from './app/routes/documentation.js';
 import readme from './app/routes/readme.js';
 
 //APIs for content sections
-import subscriptionLinkingApi from './app/routes/subscription-linking/api.js'
-import publicationApi from './app/routes/publication-api.js'
-import pubSub from './app/routes/pub-sub.js'
+import subscriptionLinkingApi from './app/routes/subscription-linking/api.js';
+import publicationApi from './app/routes/publication-api.js';
+import pubSub from './app/routes/pub-sub.js';
 
 // Proxy handles https and reverse proxy settings for running locally
 import proxy from './middleware/proxy.js';

--- a/server.js
+++ b/server.js
@@ -22,6 +22,7 @@ import readme from './app/routes/readme.js';
 //APIs for content sections
 import subscriptionLinkingApi from './app/routes/subscription-linking/api.js'
 import publicationApi from './app/routes/publication-api.js'
+import pubSub from './app/routes/pub-sub.js'
 
 // Proxy handles https and reverse proxy settings for running locally
 import proxy from './middleware/proxy.js';
@@ -61,8 +62,9 @@ app.get('/css/*', async (req, res)=>{
   }
 })
 
-app.use('/api/subscription-linking', subscriptionLinkingApi)
-app.use('/api/publication', publicationApi)
+app.use('/api/subscription-linking', subscriptionLinkingApi);
+app.use('/api/publication', publicationApi);
+app.use('/api/pub-sub', pubSub);
 
 // Boot the server
 console.log(


### PR DESCRIPTION
This PR adds a pub/sub logger, and surfaces some additional endpoints to work with it:

- `POST /api/pub-sub/receive` is designed to receive push notifications from a Cloud Pub/Sub subscription, and log them using Cloud Datastore.
- `GET /api/pub-sub/received` is a convenience method for dumping all logged pub/sub notifications from Cloud Datastore.
- `app/content/pub-sub.md` Walks through the high-level of how to create a topic and subscription, and hook it up to this logger.