### PR TITLE
Feature/account linking

### DIFF
--- a/app/content/account-linking.md
+++ b/app/content/account-linking.md
@@ -8,7 +8,7 @@
 
 ## Client-side Javascript Demo
 
-This button will attempt to link your account. Afterwards, if you authenticate 
+This button will attempt to link your Google account to a "publisher" account. Afterwards, if you authenticate 
 as the same user in the [Publication API](/reference/publication-api) example,
 the default linked entitlements will be visible via the `/entitlements` endpoint.
 
@@ -38,7 +38,6 @@ The Console DevTool is available to test account linking. For more information, 
 
 1. Include [swg.js](https://developers.google.com/news/reader-revenue/monetization/prerequisites/configure-javascript): `<script async src="https://news.google.com/swg/js/v1/swg.js"></script>`.
 1. Include the appropriate [structured data markup](https://developers.google.com/news/reader-revenue/monetization/prerequisites/structured-data-markup) for the page.
-1. Include and configure [Sign in with Google](https://developers.google.com/identity/gsi/web/guides/overview): `<script async src="https://apis.google.com/js/platform.js"></script>`.
 1. Load the sample page and click on "Link your account" button.
 
 ```html

--- a/app/content/account-linking.md
+++ b/app/content/account-linking.md
@@ -36,9 +36,10 @@ The Console DevTool is available to test account linking. For more information, 
 
 ## Sample Implementation
 
-1. Include `swg.js`: `<script async src="https://news.google.com/swg/js/v1/swg.js"></script>`
-1. Include Google Platform Library: `<script async src="https://apis.google.com/js/platform.js"></script>`
-1. Click on "Link your account"
+1. Include [swg.js](https://developers.google.com/news/reader-revenue/monetization/prerequisites/configure-javascript): `<script async src="https://news.google.com/swg/js/v1/swg.js"></script>`.
+1. Include the appropriate [structured data markup](https://developers.google.com/news/reader-revenue/monetization/prerequisites/structured-data-markup) for the page.
+1. Include and configure [Sign in with Google](https://developers.google.com/identity/gsi/web/guides/overview): `<script async src="https://apis.google.com/js/platform.js"></script>`.
+1. Load the sample page and click on "Link your account" button.
 
 ```html
 <script async type="application/javascript" src="https://news.google.com/swg/js/v1/swg.js"></script>
@@ -46,7 +47,7 @@ The Console DevTool is available to test account linking. For more information, 
   {
     "@context": "http://schema.org",
     "@type": "NewsArticle",
-    "headline": "gTech Swg Demo",
+    "headline": "Reader Revenue Demo",
     "image": "/icons/icon-2x.png",
     "datePublished": "2025-02-05T08:00:00+08:00",
     "dateModified": "2025-02-05T09:20:00+08:00",
@@ -55,9 +56,9 @@ The Console DevTool is available to test account linking. For more information, 
     "name": "John Doe"
     },
     "publisher": {
-        "name": "GTech Demo Pub News",
+        "name": "Reader Revenue Demo",
         "@type": "Organization",
-        "@id": "gtech-demo-staging.appspot.com",
+        "@id": "CAowqfCKCw",
         "logo": {
         "@type": "ImageObject",
         "url": "/icons/icon-2x.png"
@@ -67,8 +68,8 @@ The Console DevTool is available to test account linking. For more information, 
     "isAccessibleForFree": "False",
     "isPartOf": {
         "@type": ["CreativeWork", "Product"],
-        "name" : "GTech Demo Pub News basic",
-        "productID": "gtech-demo-staging.appspot.com:basic"
+        "name" : "Reader Revenue Demo",
+        "productID": "CAowqfCKCw:basic"
     }
   }
 </script>

--- a/app/content/account-linking.md
+++ b/app/content/account-linking.md
@@ -5,6 +5,80 @@
 </script>
 
 # Account Linking
+
 ## Client-side Javascript Demo
 
-This form has a randomly created ppid, but can be set by the reader.
+This button will attempt to link your account. Afterwards, if you authenticate 
+as the same user in the [Publication API](/reference/publication-api) example,
+the default linked entitlements will be visible via the `/entitlements` endpoint.
+
+To unlink this account (and remove the entitlements), visit the Google
+[My Account - Subscriptions](https://myaccount.google.com/subscriptions)
+management page and choose "unlink" next to the newly linked publication.
+
+!!! caution **Local and Linked State**
+Resetting the local account linking state using the sample `accountLinkingPersistence`
+class does not reset or unlink the user in their `My Account` page. It is a
+convenience button to help developers quickly reset the local state only.
+!!!
+
+<button id="accountLink" class="btn btn-primary">Link your account with Account Linking</button>
+<button id="accountLinkReset" class="btn btn-secondary">Reset your local account linking state cache</button>
+<div id="output"></div>
+
+## Implementation Details
+
+Read the documentation.
+
+Entitlements API and other required endpoints for OAuth 2.0 flow need to be defined in Publisher Center. For more information setting up endpoints, please read Set up Subscribe with Google for your publication.
+
+The Console DevTool is available to test account linking. For more information, please read Test account linking.
+
+## Sample Implementation
+
+1. Include `swg.js`: `<script async src="https://news.google.com/swg/js/v1/swg.js"></script>`
+1. Include Google Platform Library: `<script async src="https://apis.google.com/js/platform.js"></script>`
+1. Click on "Link your account"
+
+```html
+<script async type="application/javascript" src="https://news.google.com/swg/js/v1/swg.js"></script>
+<script type="application/ld+json">
+  {
+    "@context": "http://schema.org",
+    "@type": "NewsArticle",
+    "headline": "gTech Swg Demo",
+    "image": "/icons/icon-2x.png",
+    "datePublished": "2025-02-05T08:00:00+08:00",
+    "dateModified": "2025-02-05T09:20:00+08:00",
+    "author": {
+    "@type": "Person",
+    "name": "John Doe"
+    },
+    "publisher": {
+        "name": "GTech Demo Pub News",
+        "@type": "Organization",
+        "@id": "gtech-demo-staging.appspot.com",
+        "logo": {
+        "@type": "ImageObject",
+        "url": "/icons/icon-2x.png"
+        }
+    },
+    "description": "This example loads a carousel of offers on click.",
+    "isAccessibleForFree": "False",
+    "isPartOf": {
+        "@type": ["CreativeWork", "Product"],
+        "name" : "GTech Demo Pub News basic",
+        "productID": "gtech-demo-staging.appspot.com:basic"
+    }
+  }
+</script>
+<script>
+  (self.SWG = self.SWG || []).push( async subscriptions => {
+    // For OAuth 2.0 authorization code flow the Promise should resolve with { authCode: 'auth_code' }
+    // For OAuth 2.0 implicit flow the  Promise should resolve with { token: 'entitlements_access_token' }
+    const requestPromise = Promise.resolve({ token: 'publisher_provided_access_token' });
+    const result = await subscriptions.saveSubscription(() => requestPromise);
+    console.log("User Acceptance", result ? "Yes" : "No");
+  })
+</script>
+```

--- a/app/content/account-linking.md
+++ b/app/content/account-linking.md
@@ -1,0 +1,10 @@
+<script async
+  subscriptions-control="manual" 
+  type="application/javascript"
+  src="https://news.google.com/swg/js/v1/swg.js">
+</script>
+
+# Account Linking
+## Client-side Javascript Demo
+
+This form has a randomly created ppid, but can be set by the reader.

--- a/app/routes/account-linking/api.js
+++ b/app/routes/account-linking/api.js
@@ -21,6 +21,13 @@ const router = express.Router();
 
 router.get('/', async (req, res)=>{
 
+  /**
+ * Fetch and return 'basic' entitlements
+ * In a production environment, a publisher would fetch entitlements for
+ * the access_token by quering their user/entitlements store and
+ * returning the appropriate entitlements. In this example, a 'basic'
+ * entitlement is returned for all access_tokens.
+ */
   const entitlements = new Entitlements(req.query["access_token"]);
 
   return res.json(entitlements.fetch('basic'));

--- a/app/routes/account-linking/api.js
+++ b/app/routes/account-linking/api.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+import { Entitlements } from './entitlements.js';
+
+const router = express.Router();
+
+router.get('/', async (req, res)=>{
+
+  const entitlements = new Entitlements(req.query["access_token"]);
+
+  return res.json(entitlements.fetch('basic'));
+
+})
+
+export default router;

--- a/app/routes/account-linking/entitlements.js
+++ b/app/routes/account-linking/entitlements.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class Entitlements {
+  constructor(accessToken = undefined, publicationId = process.env.PUBLICATION_ID) {
+    this.publicationId = publicationId;
+    this.accessToken = accessToken;
+  }
+
+  fetch() {
+
+    //basic placeholder for all responses
+    const productId = 'basic';
+
+    try {
+
+      console.log(`Returned ${this.publicationId}:${productId} for accessToken: ${this.accessToken}`)
+      return {
+        "source": this.publicationId,
+        "products": [`${this.publicationId}:${productId}`],
+        "subscriptionToken": "An opaque token that has meaning for publisher.",
+        "detail" : `A ${productId} entitlement for the ${this.publicationId} publication, for accessToken ${this.accessToken}`
+      };
+
+    } catch (e) {
+
+      console.log(`Failed to fetch entitlements for ${this.publicationId}:${productId}`)
+    
+    }
+  }
+}
+
+export {Entitlements};

--- a/app/routes/account-linking/entitlements.js
+++ b/app/routes/account-linking/entitlements.js
@@ -20,10 +20,7 @@ class Entitlements {
     this.accessToken = accessToken;
   }
 
-  fetch() {
-
-    //basic placeholder for all responses
-    const productId = 'basic';
+  fetch(productId) {
 
     try {
 

--- a/app/routes/account-linking/entitlements.js
+++ b/app/routes/account-linking/entitlements.js
@@ -23,19 +23,25 @@ class Entitlements {
   fetch(productId) {
 
     try {
+      
+      //A mock of an opaque token that has meaning for publisher
+      const subscriptionToken = Buffer.from(JSON.stringify({
+        accessToken: this.accessToken,
+        productId,
+        publicationId: this.publicationId,
+        timestamp: Date.now()
+      }), "utf8").toString("base64")
 
       console.log(`Returned ${this.publicationId}:${productId} for accessToken: ${this.accessToken}`)
       return {
         "source": this.publicationId,
         "products": [`${this.publicationId}:${productId}`],
-        "subscriptionToken": "An opaque token that has meaning for publisher.",
+        "subscriptionToken": subscriptionToken,
         "detail" : `A ${productId} entitlement for the ${this.publicationId} publication, for accessToken ${this.accessToken}`
       };
 
     } catch (e) {
-
-      console.log(`Failed to fetch entitlements for ${this.publicationId}:${productId}`)
-    
+      console.log(`Failed to fetch entitlements for ${this.publicationId}:${productId}`, e);
     }
   }
 }

--- a/lib/nav/documentation.js
+++ b/lib/nav/documentation.js
@@ -69,10 +69,16 @@ const sections = [
   {
     section: 'Syncing Publisher Entitlements to Google',
     links: [{
-      label: 'Client-side',
+      label: 'Subscription Linking - Client-side',
       url: '/subscription-linking/client-side',
       content: 'app/content/subscription-linking.md',
       script: 'js/subscription-linking.js'
+    },
+    {
+      label: 'Account Linking - Client-side (deprecated)',
+      url: '/account-linking/client-side',
+      content: 'app/content/account-linking.md',
+      script: 'js/account-linking.js'
     }]
   },
   {

--- a/public/js/account-linking-persistence.js
+++ b/public/js/account-linking-persistence.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Class for use with managing 
+ */
+
+class accountLinkingPersistence {
+  constructor() {
+    this._linked = false;
+    this._declined = false;
+    this.accessToken = undefined;
+    this.refresh();
+    this.generateAccessToken();
+  }
+
+  set linked(item) {
+    this._linked = item;
+    this.save()
+  }
+
+  get linked() {
+    return this._linked;
+  }
+
+  set declined(declineState) {
+    this._declined = declineState;
+    this.save();
+  }
+
+  get declined() {
+    return this._declined;
+  }
+
+  get state() {
+    return {
+      linked: this._linked,
+      declined: this._declined,
+      accessToken: this.accessToken
+    }
+  }
+
+  generateAccessToken(ppid = undefined) {
+    if(this.accessToken !== undefined) return;
+
+    this.accessToken = `entitlements_access_token_${ppid ? ppid : Math.round(Math.random()*1000)}`;
+    this.save();
+  }
+
+  refresh() {
+    try {
+      const {linked, declined, accessToken} = JSON.parse(localStorage.getItem("accountLinkingPersistence"));
+      this._linked = linked;
+      this._declined = declined;
+      this.accessToken = accessToken;
+    } catch (e) {
+      console.log("Unable to restore state from localStorage");
+    }
+  }
+
+  save() {
+    const {linked, declined, accessToken} = this;
+    localStorage.setItem("accountLinkingPersistence", JSON.stringify({linked, declined, accessToken}));
+  }
+
+  reset() {
+    localStorage.removeItem("accountLinkingPersistence");
+  }
+}
+
+export {accountLinkingPersistence};

--- a/public/js/account-linking-persistence.js
+++ b/public/js/account-linking-persistence.js
@@ -15,9 +15,21 @@
  */
 
 /**
- * @fileoverview Class for use with managing 
+ * @fileoverview Class for use with managing and persisting account linking
+ * state in the browser's localStorage. 
  */
 
+
+/**
+ * accountLinkingPersistence
+ * A class that exposes convenience functions for managing account linking
+ * state, using the browser's localStorage as a cache. 
+ * 
+ * Note: In a production environment, a class like this could be used to 
+ * store and retrieve access_tokens and state information from a database.
+ * This example class mocks access_token generation, and stores state only
+ * in the browser's localStorage, which is temporary.
+ */
 class accountLinkingPersistence {
   constructor() {
     this._linked = false;
@@ -27,8 +39,8 @@ class accountLinkingPersistence {
     this.generateAccessToken();
   }
 
-  set linked(item) {
-    this._linked = item;
+  set linked(isLinked) {
+    this._linked = isLinked;
     this.save()
   }
 
@@ -36,8 +48,8 @@ class accountLinkingPersistence {
     return this._linked;
   }
 
-  set declined(declineState) {
-    this._declined = declineState;
+  set declined(isDeclined) {
+    this._declined = isDeclined;
     this.save();
   }
 

--- a/public/js/account-linking.js
+++ b/public/js/account-linking.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview This client-side js file to initiate and manage account
+ * linking state.
+ */
+import {insertHighlightedJson} from './utils.js';
+import {accountLinkingPersistence} from './account-linking-persistence.js';
+
+async function handleSavedSubscription(accessToken) {
+  return {token: accessToken};
+}
+
+(self.SWG = self.SWG || []).push(async function(subscriptions) {
+
+  //initialize Account Linking helper 
+  const accountLinkingState = new accountLinkingPersistence;
+  
+  //initialize SwG
+  subscriptions.init('process.env.PUBLICATION_ID');
+  
+  //query publisher local entitlements
+
+  //show local entitlements
+  if (accountLinkingState.linked === true) {
+    const endpoint = `/api/account-linking?access_token=${accountLinkingState.accessToken}`;
+    const localEntitlements = await fetch(endpoint).then(r=>r.json());
+    insertHighlightedJson('#output', localEntitlements, `Publisher entitlements for accessToken:${accountLinkingState.accessToken}`);
+  }
+
+  //show account linking local state
+  insertHighlightedJson('#output', accountLinkingState.state, "Local Account Linking State");
+
+  //update the state of buttons
+  const linkButton = document.querySelector('#accountLink');
+  const resetButton = document.querySelector('#accountLinkReset');
+
+  resetButton.onclick = () => {
+    accountLinkingState.reset();
+    location.reload()
+  }
+
+  linkButton.onclick = async ()=>{
+    const response = await subscriptions.saveSubscription(()=>{
+      return handleSavedSubscription(accountLinkingState.accessToken);
+    })
+    accountLinkingState.declined = !response;
+    accountLinkingState.linked = response;
+
+    insertHighlightedJson('#output', {response}, "Account Linking Response");
+  }
+
+  if(accountLinkingState.declined === true) {
+    linkButton.setAttribute('disabled', true);
+    linkButton.textContent = "User previously declined to link.";
+  }
+
+  if(accountLinkingState.linked === true) {
+    linkButton.textContent = "User previously link. Link again?";
+  }
+
+});

--- a/server.js
+++ b/server.js
@@ -23,6 +23,7 @@ import readme from './app/routes/readme.js';
 import subscriptionLinkingApi from './app/routes/subscription-linking/api.js';
 import publicationApi from './app/routes/publication-api.js';
 import pubSub from './app/routes/pub-sub.js';
+import accountLinkingApi from './app/routes/account-linking/api.js';
 
 // Proxy handles https and reverse proxy settings for running locally
 import proxy from './middleware/proxy.js';
@@ -65,6 +66,7 @@ app.get('/css/*', async (req, res)=>{
 app.use('/api/subscription-linking', subscriptionLinkingApi);
 app.use('/api/publication', publicationApi);
 app.use('/api/pub-sub', pubSub);
+app.use('/api/account-linking', accountLinkingApi);
 
 // Boot the server
 console.log(


### PR DESCRIPTION
This PR adds Account Linking functionality to the `reader-revenue-demo` app. This PR is deployed to a testing instance at [account-linking-upgrade](https://account-linking-upgrade-dot-reader-revenue-demo.ue.r.appspot.com/account-linking/client-side).

Significant changes:

- Adds a detailed article at `app/content/account-linking.md`
- Adds the `/api/account-linking` endpoint via the `app/routes/account-linking/api.js` router and it's helper class in `app/routes/account-linking/entitlements.js`
- Adds a client-side javascript example of triggering account linking at `public/js/account-linking.js`, and a helper class for managing a localStorage cache of user state via `public/js/account-linking-persistence.js`