### PR TITLE
Feature/extended access

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ PROXY_URL=local.domain
 HOST=0.0.0.0
 DISABLE_SSL=true
 
+# Settings for signed cookies
+COOKIE_SECRET=secret
+
 # GCP-specific env vars for external service communication
 GOOGLE_CLOUD_REGION=us-east1
 GOOGLE_APPLICATION_CREDENTIALS=/path/to/application_default_credentials.json

--- a/app/content/extended-access-registration.md
+++ b/app/content/extended-access-registration.md
@@ -1,0 +1,14 @@
+<script async src="https://accounts.google.com/gsi/client" defer></script>
+<script async subscriptions-control="manual" src="https://news.google.com/swg/js/v1/swg.js"></script>
+<script async src="https://news.google.com/swg/js/v1/swg-gaa.js"></script>
+
+<button id="redirect">Simulate Showcase Click</button>
+<button id="revoke">Revoke GIS Token Grant</button>
+## fancy ea registration page
+
+
+<p id="paywalledContent" style="filter: blur(4px)">
+  This content is paywalled or behind a registration wall.
+</p>
+
+<div id="output"></div>

--- a/app/content/extended-access-registration.md
+++ b/app/content/extended-access-registration.md
@@ -2,13 +2,29 @@
 <script async subscriptions-control="manual" src="https://news.google.com/swg/js/v1/swg.js"></script>
 <script async src="https://news.google.com/swg/js/v1/swg-gaa.js"></script>
 
-<button id="redirect">Simulate Showcase Click</button>
-<button id="revoke">Revoke GIS Token Grant</button>
-## fancy ea registration page
+# Extended Access - Registration Flow
 
+Launch a registration dialog for anonymous users to sign up and gain extended access to paid articles.
+
+By clicking on 'Continue with Google', readers let Google share their Google profile information with 
+you. The user profile information object is the same as the one you get from [Sign in with Google](https://developers.google.com/identity/gsi/web/reference/js-reference#credential),
+and can be used to create an account for the user. We recommend using the value of the `sub` field
+to uniquely identify users, as email addresses may change, or become unavailable in the future.
+
+## Simulated Paywalled Content
 
 <p id="paywalledContent" style="filter: blur(4px)">
   This content is paywalled or behind a registration wall.
 </p>
 
+<button id="redirect" class="btn btn-primary">Simulate Showcase Click</button>
+<button id="revoke" class="btn btn-secondary">Revoke GIS Token Grant</button>
+
 <div id="output"></div>
+
+!!! note **State Maintenance**
+Google maintains no session state for the user. It is up to the publisher to handle state after registration through their existing user state management system.
+!!!
+
+For more information, read the [documentation](https://developers.google.com/news/subscribe/extended-access/integration-steps/web-implementation?feed=client-side#handle-registration-for-new-users)
+and [code samples](https://developers.google.com/news/subscribe/extended-access/reference/sample-code?paywall_type=client-side#code-select).

--- a/app/content/overview.md
+++ b/app/content/overview.md
@@ -56,6 +56,9 @@ PROXY_URL=local.domain
 HOST=0.0.0.0
 DISABLE_SSL=true
 
+# Settings for signed cookies
+COOKIE_SECRET=secret
+
 # GCP-specific env vars for external service communication
 GOOGLE_CLOUD_REGION=us-east1
 GOOGLE_APPLICATION_CREDENTIALS=/path/to/application_default_credentials.json

--- a/app/routes/extended-access.js
+++ b/app/routes/extended-access.js
@@ -15,10 +15,58 @@
  */
 
 import express from 'express';
-const router = express.Router();
+import bodyParser from 'body-parser';
 
+const router = express.Router();
+/**
+ * GET /api/extended-access/cookie/:cookieName
+ * A getter method that returns the current httpOnly cookie.
+ * This can be done client-side too, and is here for consistency.
+ */
+router.get('/cookie/:cookieName', async (req, res) =>{
+  try {
+    const cookie = req.cookies[req.params['cookieName']];
+    return res.json({cookie});
+  } catch (e) {
+    console.log(e);
+    return res.status(500).json({error:e});
+  }
+})
+
+/**
+ * POST /api/extended-access/cookie
+ * Create an httpOnly cookie. Parses the POST body to set an
+ * expiry date.
+ */
+router.post('/cookie', bodyParser.json(), async (req, res) =>{
+  try {
+    const { name, value, expiresInDays } = req.body;
+
+    res.cookie(name, value, {
+      expires: new Date(Date.now() + expiresInDays),
+      httpOnly: true
+    })
+
+    res.send("Cookie set");
+
+  } catch (e) {
+    console.log(e);
+    return res.status(500).end("Body unparseable");
+  }
+})
+
+/**
+ * GET /api/extended-access
+ * In this example implementation, Extended Access does not require
+ * and server-side api access, so this is intentionally left blank.
+ * In a real world configuration, a publisher may use this either
+ * for the server-side EA access flow, or as an aid to parts of the
+ * entitlements handling or user registration completion.
+ */
 router.get('/', async (req, res, next) => {
   return res.end('Extended Access route loaded');
 });
+
+
 
 export default router;

--- a/app/routes/extended-access.js
+++ b/app/routes/extended-access.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+const router = express.Router();
+
+router.get('/', async (req, res, next) => {
+  return res.end('Extended Access route loaded');
+});
+
+export default router;

--- a/lib/nav/documentation.js
+++ b/lib/nav/documentation.js
@@ -67,6 +67,15 @@ const sections = [
     ]
   },
   {
+    section: 'Using Extended Access',
+    links: [{
+      label: 'Registration Flow',
+      url: '/extended-access/registration',
+      content: 'app/content/extended-access-registration.md',
+      script: 'js/extended-access.js'
+    }]
+  },
+  {
     section: 'Syncing Publisher Entitlements to Google',
     links: [{
       label: 'Subscription Linking - Client-side',

--- a/lib/renderers.js
+++ b/lib/renderers.js
@@ -131,4 +131,13 @@ async function renderStaticFile(filePath, data = {}) {
   }
 }
 
-export {renderMarkdown, renderHtml, renderStaticFile};
+async function renderStaticImage(filePath) {
+  try {
+    return await readFile(filePath);
+  } catch (e) {
+    console.log(e);
+    throw new Error("Static image wasn't parseable", e);
+  }
+}
+
+export {renderMarkdown, renderHtml, renderStaticFile, renderStaticImage};

--- a/lib/renderers.js
+++ b/lib/renderers.js
@@ -30,9 +30,9 @@ import hljs from 'highlight.js';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 function safeEnvVars() {
-  const {GOOGLE_SITE_VERIFICATION, OAUTH_CLIENT_ID, PUBLICATION_ID, ENV_NAME} =
+  const {GOOGLE_SITE_VERIFICATION, OAUTH_CLIENT_ID, PUBLICATION_ID, ENV_NAME, PROXY_URL} =
       process.env;
-  return {GOOGLE_SITE_VERIFICATION, OAUTH_CLIENT_ID, PUBLICATION_ID, ENV_NAME};
+  return {GOOGLE_SITE_VERIFICATION, OAUTH_CLIENT_ID, PUBLICATION_ID, ENV_NAME, PROXY_URL};
 }
 
 marked.use({

--- a/middleware/cookies.js
+++ b/middleware/cookies.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cookieParser from "cookie-parser";
+
+
+
+export default cookieParser(process.env.COOKIE_SECRET || '');

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@google-cloud/firestore": "^6.5.0",
         "@google-cloud/pubsub": "^3.7.0",
         "body-parser": "^1.20.2",
+        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "express-handlebars": "^7.0.2",
@@ -4085,6 +4086,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@google-cloud/firestore": "^6.5.0",
     "@google-cloud/pubsub": "^3.7.0",
     "body-parser": "^1.20.2",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "express-handlebars": "^7.0.2",

--- a/public/js/extended-access.js
+++ b/public/js/extended-access.js
@@ -1,0 +1,248 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview This client-side js file to initiate and manage account
+ * linking state.
+ */
+
+
+
+console.log('ea-registration.js file loaded correctly')
+    
+  
+import { insertHighlightedJson } from './utils.js';
+
+function revokeIDToken() {
+  google.accounts.id.revoke(readCookie('jwtSub'), done => {
+    console.log(done.error);
+  });
+  eraseCookie('jwtSub');
+}
+
+function createCookie(name, value, days=15) {
+  var expires = '',
+      date = new Date();
+  if (days) {
+      date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+      expires = '; expires=' + date.toGMTString();
+  }
+  document.cookie = name + '=' + value + expires + '; path=/';
+}
+
+function readCookie(name) {
+    var cookies = document.cookie.split(';'),
+        length = cookies.length,
+        i,
+        cookie,
+        nameEQ = name + '=';
+    for (i = 0; i < length; i += 1) {
+        cookie = cookies[i];
+        while (cookie.charAt(0) === ' ') {
+            cookie = cookie.substring(1, cookie.length);
+        }
+        if (cookie.indexOf(nameEQ) === 0) {
+            return cookie.substring(nameEQ.length, cookie.length);
+        }
+    }
+    return null;
+}
+
+function eraseCookie(name) {
+    createCookie(name, '', -1);
+}
+
+function parseJwt (token) {
+    var base64Url = token.split('.')[1];
+    var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    var jsonPayload = decodeURIComponent(atob(base64).split('').map(function(c) {
+        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+    }).join(''));
+
+    return JSON.parse(jsonPayload);
+}
+
+function redirect() {
+  console.log("redirect happening...")
+  const url = `https://play.google.com/newsstand/api/v3/articleaccess?testurl=https://${window.location.host}/extended-access/registration`;
+  window.location.href = url
+}
+
+function InitGaaMetering() {
+  /**
+   * Publisher-defined callbacks.
+   *
+   * The simplest possible implementation of showPaywall, unlockArticle, openLoginPage
+   * and handleSwGEntitlement. A more sophisticated implementation could fetch more data,
+   * or set cookies and refresh the whole page.
+   */
+
+  // Callback that must ensure the publisher’s standard paywall is shown to the user.
+  // This is used when Extended Access is not granted to the user or if the user
+  // clicks “Subscribe” on the Extended Access prompt.
+  // Do not copy the implementation for the callback and see documentation for your own implementation at:
+  // https://developers.google.com/news/subscribe/extended-access/integration-steps/web-implementation#handle-extended-access-grants
+  function showPaywall() {
+    console.log('Example: show paywall');
+  };
+
+  // Callback that must unlock the current article which is called when Google is
+  // granting Extended Access to the user.
+  // Do not copy the implementation for the callback and see documentation for your own implementation at:
+  // https://developers.google.com/news/subscribe/extended-access/integration-steps/web-implementation#handle-extended-access-grants
+  function unlockArticle() {
+    document.getElementById("paywalledContent").style.filter = "blur(0px)"
+    console.log('Example: unlock article');
+  };
+
+  // Only relevant for publishers doing Subscribe with Google.
+  // Callback that will be triggered if the user is a Subscribe with Google subscriber.
+  // Do not copy the implementation for the callback and see documentation for your own implementation at:
+  // https://developers.google.com/news/subscribe/guides/check-for-entitlements-on-web
+  function handleSwGEntitlement() {
+    console.log('Example: handle swg entitlement');
+    unlockArticle();
+  }
+
+
+  /*
+    * Publisher-defined promises.
+    *
+    * The simplest implementation of registerUserPromise, handleLoginPromise,
+    * and publisherEntitlementPromise.
+    */
+  // Get userState by passing the gaaUser object to your registration endpoint server
+  // Takes the registration JWT and returns an updated userState object for the newly registered user.
+  // Do not copy the implementation for the promise and see documentation for your own implementation at:
+  // https://developers.google.com/news/subscribe/extended-access/integration-steps/web-implementation#handle-registration-for-new-users
+  const registerUserPromise = new Promise ((resolve) => {
+    GaaMetering.getGaaUserPromise().then((gaaUser) => {
+      createCookie('jwtSub', gaaUser.credential.sub)
+
+      insertHighlightedJson("#output", parseJwt(gaaUser.credential))
+
+      createCookie('jwtSub', parseJwt(gaaUser.credential).sub)
+      // gaaUser - registration JWT that is returned by Sign In with Google
+      // https://developers.google.com/identity/gsi/web/reference/js-reference?hl=en#credential
+      const gaaUserDecoded = parseJwt(gaaUser.credential);
+      // Example body of the promise returning a userState object
+      const userState = {
+        id: btoa(gaaUserDecoded.sub),
+        registrationTimestamp: Math.round(Date.now() / 1000),
+        granted: false
+      };
+      resolve(userState);
+    });
+  });
+
+  // Allows the user to login to an existing publisher account and must resolve
+  // with an updated userState object for the newly logged-in user.
+  // Do not copy the implementation for the promise and see documentation for your own implementation at:
+  // https://developers.google.com/news/subscribe/extended-access/integration-steps/web-implementation#handle-login-for-existing-users
+  const handleLoginPromise = new Promise ((resolve) => {
+    GaaMetering.getLoginPromise().then(() => {
+      alert('You may open your log in page');
+      // Example body of the promise returning a userState object
+      const userState = {
+        id: 'user123456789',
+        registrationTimestamp: 1647311022,
+        granted: false,
+      };
+
+      insertHighlightedJson("#output", {message:"User identified via Publisher's sign in"})
+      resolve(userState);
+    });
+  });
+
+  // Get userState by passing the gaaUser object to your registration endpoint server
+  // Resolves with the current user’s entitlements from the publisher
+  // Optional - required only if your userState object doesn't contain the publisherEntitlement already
+  // Do not copy the implementation for the promise and see documentation for your own implementation at:
+  // https://developers.google.com/news/subscribe/extended-access/integration-steps/web-implementation#creating-the-users-entitlement-state
+  const publisherEntitlementPromise = new Promise ((resolve) => {
+    // Example body of the promise returning a publisherEntitlement object
+    const publisherEntitlement = {
+      granted: false,
+    };
+    resolve(publisherEntitlement);
+  });
+
+  // The userState object for the current user.
+  // Do not copy the implementation for the callback and see documentation for your own implementation at:
+  // https://developers.google.com/news/subscribe/extended-access/reference/user-state-object
+  function getUserState() {
+    return {
+      // Commented out since we don't actually use the UserState in this demo of the
+      // registration flow.
+      // id: 'user123456789',
+      // registrationTimestamp: 1647311022,
+      // subscriptionTimestamp: 1647311062,
+      // granted: true,
+      // grantReason: 'SUBSCRIBER'
+    };
+  };
+
+  /* Code */
+
+  // Provide a shortcut to metering params.
+  // Do not copy the constant and see documentation at:
+  // https://developers.google.com/news/subscribe/extended-access/reference/google-article-access-parameters
+  const urlParams = new URLSearchParams(location.search);
+  if (urlParams.has('metering')) {
+    let newSearch = 'gaa_at=g&gaa_ts=99999999&gaa_n=n0nc3&gaa_sig=51g';
+    location.search = newSearch;
+  }
+
+
+  // Array with all allowed hosts that can refer users to your article pages.
+  // This is used if you redirect users or refresh the page during the Handle registration
+  // for new users or Handle login for existing users flows.
+  // Do not copy the constant and see documentation at:
+  // https://developers.google.com/news/subscribe/extended-access/integration-steps/web-implementation#initialize-the-extended-access-library
+  const allowedReferrers = ["ea-upgrade-dot-reader-revenue-demo.ue.r.appspot.com",
+                            "ea-upgrade-to-rrme-dot-reader-revenue-demo.ue.r.appspot.com",
+                            "b2607f8b04800100000144d90c0a821641f90000000000000000001.proxy.googlers.com"]
+
+  // User's Showcase entitlement determined on your server
+  // Optional - server side only
+  // Do not copy the constant and see documentation at:
+  // https://developers.google.com/news/subscribe/guides/check-for-entitlements-on-web
+  const showcaseEntitlement = urlParams.get("showcaseEntitlement");
+
+  // Do not copy the parameters bellow. See documentation at:
+  // https://developers.google.com/news/subscribe/extended-access/integration-steps/web-implementation#initialize-the-extended-access-library
+
+
+  GaaMetering.init({
+    googleApiClientId: '695298810691-sue9beofr6jstu5e227oh4jpatljlt1p.apps.googleusercontent.com',
+    allowedReferrers: allowedReferrers,
+    userState: getUserState(),
+    unlockArticle: unlockArticle,
+    showPaywall: showPaywall,
+    handleSwGEntitlement: handleSwGEntitlement, // Optional - only if SwG is implemented
+    registerUserPromise: registerUserPromise,
+    handleLoginPromise: handleLoginPromise,
+    publisherEntitlementPromise: publisherEntitlementPromise, // Optional
+  });
+}
+
+
+
+document.addEventListener("DOMContentLoaded", (event) => {
+  InitGaaMetering()
+  document.querySelector("#redirect").onclick = redirect
+  document.querySelector("#revoke").onclick = revokeIDToken
+});

--- a/public/js/extended-access.js
+++ b/public/js/extended-access.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,10 @@
  */
 
 /**
- * @fileoverview This client-side js file to initiate and manage account
- * linking state.
+ * @fileoverview This client-side js file to initiate and manage
+ * Extended Access registration and entitlements
  */
 
-
-
-console.log('ea-registration.js file loaded correctly')
-    
-  
 import { insertHighlightedJson } from './utils.js';
 
 function revokeIDToken() {
@@ -132,7 +127,7 @@ function InitGaaMetering() {
     GaaMetering.getGaaUserPromise().then((gaaUser) => {
       createCookie('jwtSub', gaaUser.credential.sub)
 
-      insertHighlightedJson("#output", parseJwt(gaaUser.credential))
+      insertHighlightedJson("#output", parseJwt(gaaUser.credential), "GAA User Credentials from the JWT")
 
       createCookie('jwtSub', parseJwt(gaaUser.credential).sub)
       // gaaUser - registration JWT that is returned by Sign In with Google
@@ -162,7 +157,7 @@ function InitGaaMetering() {
         granted: false,
       };
 
-      insertHighlightedJson("#output", {message:"User identified via Publisher's sign in"})
+      insertHighlightedJson("#output", {message:"User identified via Publisher's sign in"}, "User with Publisher Login")
       resolve(userState);
     });
   });
@@ -225,7 +220,6 @@ function InitGaaMetering() {
   // Do not copy the parameters bellow. See documentation at:
   // https://developers.google.com/news/subscribe/extended-access/integration-steps/web-implementation#initialize-the-extended-access-library
 
-
   GaaMetering.init({
     googleApiClientId: '695298810691-sue9beofr6jstu5e227oh4jpatljlt1p.apps.googleusercontent.com',
     allowedReferrers: allowedReferrers,
@@ -238,8 +232,6 @@ function InitGaaMetering() {
     publisherEntitlementPromise: publisherEntitlementPromise, // Optional
   });
 }
-
-
 
 document.addEventListener("DOMContentLoaded", (event) => {
   InitGaaMetering()

--- a/server.js
+++ b/server.js
@@ -29,7 +29,8 @@ import extendedAccess from './app/routes/extended-access.js'
 // Proxy handles https and reverse proxy settings for running locally
 import proxy from './middleware/proxy.js';
 import ssl from './middleware/ssl.js';
-import overrides from './middleware/overrides.js'
+import overrides from './middleware/overrides.js';
+import cookies from './middleware/cookies.js';
 
 //test
 import { renderStaticFile } from './lib/renderers.js';
@@ -40,6 +41,7 @@ app.set('trust proxy', 'loopback');
 app.use(proxy);
 app.use(ssl);
 app.use(overrides);
+app.use(cookies);
 
 // Mount APIs for content sections
 app.use('/readme', readme);

--- a/server.js
+++ b/server.js
@@ -33,7 +33,7 @@ import overrides from './middleware/overrides.js';
 import cookies from './middleware/cookies.js';
 
 //test
-import { renderStaticFile } from './lib/renderers.js';
+import { renderStaticFile, renderStaticImage } from './lib/renderers.js';
 
 // Configure app globals
 const app = express();
@@ -46,6 +46,15 @@ app.use(cookies);
 // Mount APIs for content sections
 app.use('/readme', readme);
 app.use('/', readerRevenue);
+
+app.get('/img/*', async (req, res)=>{
+  try {
+    const image = await renderStaticImage(`public/${req.path}`);
+    res.set('Content-Type',`image/${req.path.split('.').pop()}`).end(image);
+  } catch(e) {
+    res.status(500).end(`Error: failed to render ${req.path}`);
+  }
+})
 
 app.get('/js/*', async (req, res)=>{
   try {

--- a/server.js
+++ b/server.js
@@ -24,6 +24,7 @@ import subscriptionLinkingApi from './app/routes/subscription-linking/api.js';
 import publicationApi from './app/routes/publication-api.js';
 import pubSub from './app/routes/pub-sub.js';
 import accountLinkingApi from './app/routes/account-linking/api.js';
+import extendedAccess from './app/routes/extended-access.js'
 
 // Proxy handles https and reverse proxy settings for running locally
 import proxy from './middleware/proxy.js';
@@ -67,6 +68,7 @@ app.use('/api/subscription-linking', subscriptionLinkingApi);
 app.use('/api/publication', publicationApi);
 app.use('/api/pub-sub', pubSub);
 app.use('/api/account-linking', accountLinkingApi);
+app.use('/api/extended-access', extendedAccess);
 
 // Boot the server
 console.log(


### PR DESCRIPTION
This PR migrates the `gtech-demo` EA example to `reader-revenue-demo`. It is deployed for preview on [ea-upgrade-to-rrme](https://ea-upgrade-to-rrme-dot-reader-revenue-demo.ue.r.appspot.com/extended-access/registration).

- `app/content/extended-access-registration.md` contains the article, with some text copied and updated from [gtech-demo](https://gtech-demo.appspot.com/html/ea-registration-latest.html)
- `public/js/extended-access.js` contains the ea implementation, pulling from both the `gtech-demo` example and the devsite docs.
 