### PR TITLE
Patch/static handlers

### DIFF
--- a/app/routes/static-handlers.js
+++ b/app/routes/static-handlers.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+import { renderStaticFile, renderStaticImage } from '../../lib/renderers.js';
+
+const img = express.Router();
+const js = express.Router();
+const css = express.Router();
+
+img.get('/*', async (req, res)=>{
+  try {
+    const image = await renderStaticImage(`public/img/${req.path}`);
+    res.set('Content-Type',`image/${req.path.split('.').pop()}`).end(image);
+  } catch(e) {
+    res.status(500).end(`Error: failed to render ${req.path}`);
+  }
+})
+
+js.get('/*', async (req, res)=>{
+  try {
+    console.log(req.path);
+    const renderedStaticFile = await renderStaticFile(`public/js/${req.path}`);
+    res.set('Content-Type','text/javascript').end(renderedStaticFile);
+  } catch(e) {
+    res.status(500).end(`Error: failed to render ${req.path}`);
+  }
+})
+
+css.get('/*', async (req, res)=>{
+  try {
+    const renderedStaticFile = await renderStaticFile(`public/css/${req.path}`);
+    res.set('Content-Type','text/css').end(renderedStaticFile);
+  } catch(e) {
+    res.status(500).end(`Error: failed to render ${req.path}`);
+  }
+})
+
+export { img, js, css };

--- a/server.js
+++ b/server.js
@@ -32,8 +32,8 @@ import ssl from './middleware/ssl.js';
 import overrides from './middleware/overrides.js';
 import cookies from './middleware/cookies.js';
 
-//test
-import { renderStaticFile, renderStaticImage } from './lib/renderers.js';
+// Static routers with some custom behavior
+import { css, js, img } from './app/routes/static-handlers.js';
 
 // Configure app globals
 const app = express();
@@ -43,43 +43,21 @@ app.use(ssl);
 app.use(overrides);
 app.use(cookies);
 
-// Mount APIs for content sections
+// Mount content sections
 app.use('/readme', readme);
 app.use('/', readerRevenue);
 
-app.get('/img/*', async (req, res)=>{
-  try {
-    const image = await renderStaticImage(`public/${req.path}`);
-    res.set('Content-Type',`image/${req.path.split('.').pop()}`).end(image);
-  } catch(e) {
-    res.status(500).end(`Error: failed to render ${req.path}`);
-  }
-})
-
-app.get('/js/*', async (req, res)=>{
-  try {
-    console.log(req.path);
-    const renderedStaticFile = await renderStaticFile(`public/${req.path}`);
-    res.set('Content-Type','text/javascript').end(renderedStaticFile);
-  } catch(e) {
-    res.status(500).end(`Error: failed to render ${req.path}`);
-  }
-})
-
-app.get('/css/*', async (req, res)=>{
-  try {
-    const renderedStaticFile = await renderStaticFile(`public/${req.path}`);
-    res.set('Content-Type','text/css').end(renderedStaticFile);
-  } catch(e) {
-    res.status(500).end(`Error: failed to render ${req.path}`);
-  }
-})
-
+// Mount APIs for content sections
 app.use('/api/subscription-linking', subscriptionLinkingApi);
 app.use('/api/publication', publicationApi);
 app.use('/api/pub-sub', pubSub);
 app.use('/api/account-linking', accountLinkingApi);
 app.use('/api/extended-access', extendedAccess);
+
+// Mount custom static file handlers
+app.use('/img', img);
+app.use('/js', js);
+app.use('/css', css);
 
 // Boot the server
 console.log(


### PR DESCRIPTION
This PR moves the logic for handling static files out of `server.js` and into `app/routes/static-handlers.js`.

- Newly created `app/routes/static-handlers.js` exports `css`, `js` and `img` routers.
- `server.js` has been updated to use the exported routers.