### PR TITLE
Updated the sl instantiation to be a variable

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -16,6 +16,9 @@ runtime: nodejs18
 service_account: ""
 service: default
 env_variables:
+  ENV_NAME: "Prod"
+  GOOGLE_SITE_VERIFICATION: ""
+  GOOGLE_CLOUD_REGION: ""
   OAUTH_CLIENT_ID: ""
   OAUTH_CLIENT_SECRET: ""
   PUBLICATION_ID: ""

--- a/app.yaml
+++ b/app.yaml
@@ -17,6 +17,7 @@ service_account: ""
 service: default
 env_variables:
   ENV_NAME: "Prod"
+  ENV_OVERRIDES: ""
   GOOGLE_SITE_VERIFICATION: ""
   GOOGLE_CLOUD_REGION: ""
   OAUTH_CLIENT_ID: ""

--- a/public/js/subscription-linking.js
+++ b/public/js/subscription-linking.js
@@ -213,7 +213,7 @@ document.addEventListener('DOMContentLoaded', function () {
   createQueryForm();
   createUpdateForm();
   (self.SWG = self.SWG || []).push(subscriptions => {
-    subscriptions.init('prod.reader-revenue-demo.ue.r.appspot.com');
+    subscriptions.init('process.env.PUBLICATION_ID');
     analyticsEventLogger(subscriptions);
   });
 });


### PR DESCRIPTION
This patch uses the [rewrite static files](https://github.com/reader-revenue/reader-revenue-demo/pull/11) feature to use the environmental variable to surface the correct `PUBLICATION_ID`.