### PR TITLE
Feature/account-linking-migration

### DIFF
--- a/app/routes/account-linking/entitlements.js
+++ b/app/routes/account-linking/entitlements.js
@@ -32,6 +32,8 @@ class Entitlements {
         timestamp: Date.now()
       }), "utf8").toString("base64");
 
+      // In production, this unique ppid would be associated with a reader,
+      // and later used to update entitlements with Subscription Linking.
       const generatePpid = Buffer.from(JSON.stringify({
         accessToken: this.accessToken,
         productId,

--- a/app/routes/account-linking/entitlements.js
+++ b/app/routes/account-linking/entitlements.js
@@ -30,14 +30,21 @@ class Entitlements {
         productId,
         publicationId: this.publicationId,
         timestamp: Date.now()
-      }), "utf8").toString("base64")
+      }), "utf8").toString("base64");
+
+      const generatePpid = Buffer.from(JSON.stringify({
+        accessToken: this.accessToken,
+        productId,
+        publicationId: this.publicationId
+      }), "utf8").toString("base64");
 
       console.log(`Returned ${this.publicationId}:${productId} for accessToken: ${this.accessToken}`)
       return {
         "source": this.publicationId,
         "products": [`${this.publicationId}:${productId}`],
         "subscriptionToken": subscriptionToken,
-        "detail" : `A ${productId} entitlement for the ${this.publicationId} publication, for accessToken ${this.accessToken}`
+        "detail" : `A ${productId} entitlement for the ${this.publicationId} publication, for accessToken ${this.accessToken}`,
+        "ppid": generatePpid
       };
 
     } catch (e) {


### PR DESCRIPTION
This PR adds a stub `ppid` to the `/entitlements` response, to trigger the Account Linking to Subscription Linking migration flow.

- The `ppid` is base64-encoded, but this is not a requirement; it must conform to [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt) as documented in the [Subscription Linking devsite](https://developers.google.com/news/subscribe/subscription-linking/implementation/ppids).