### PR TITLE
feature/disable-semantic-markup

### DIFF
--- a/app/content/overview.md
+++ b/app/content/overview.md
@@ -159,6 +159,9 @@ required unless specified:
         "url": "/", // Url (relative to root)
         "content": "app/content/test.md" // .md or .html to render,
         "script": "js/script.js" // Optional, relative to the /public folder
+        "options": { //Optional, passed directly to template rendering
+          "suppressStructuredDataMarkup" : true // suppressed the ld+json block rendering
+        }
       }
       // Insert more links for this section
     ]

--- a/app/routes/documentation.js
+++ b/app/routes/documentation.js
@@ -16,7 +16,7 @@
 
 import express from 'express';
 
-import {nav, script} from '../../lib/nav/documentation.js';
+import {nav, script, options} from '../../lib/nav/documentation.js';
 import {renderHtml, renderMarkdown} from '../../lib/renderers.js';
 
 const router = express.Router();
@@ -57,10 +57,12 @@ for (const section of nav()) {
             ? await renderMarkdown(route.content, section.template, {
                 nav: nav(req),
                 script: script(req),
+                options: options(req)
               })
             : await renderHtml(route.content, section.template, {
                 nav: nav(req),
                 script: script(req),
+                options: options(req)
               });
       } catch (e) {
         console.log(e);

--- a/app/views/layouts/demo-layout.html
+++ b/app/views/layouts/demo-layout.html
@@ -56,7 +56,11 @@
 
   {{/data.script}}
 
+  {{#unless data.options.structuredDataMarkup}}
   {{> "structured-data-markup"}}
+  {{else}}
+  <!-- Structured Data Markup suppressed by route configuration-->>
+  {{/unless}}
 
   <script defer type="module" src="js/demo-layout.js"></script>
 

--- a/lib/nav/documentation.js
+++ b/lib/nav/documentation.js
@@ -152,13 +152,26 @@ export function nav(req) {
   });
 }
 
-//this function is awful
-//i am sorry
+//These two functions exist because it is difficult in
+// app/routes/documentation.js to understand which nav
+// element is being called to key into the nav object
+// so these search for the right value instead
 export function script(req) {
   for (const current of sections) {
     for (const link of current.links) {
       if (req?.path === link.url) {
         return link.script;
+      }
+    }
+  }
+  return '';
+}
+
+export function options(req) {
+  for (const current of sections) {
+    for (const link of current.links) {
+      if (req?.path === link.url) {
+        return link.options ?? undefined;
       }
     }
   }


### PR DESCRIPTION
Allows for disabling semantic markup on a per-route basis. To suppress, define the new option in the nav. As illustrated in `overview.md`:

```javascript
      {
        "label": "Test", // Visible label
        "url": "/", // Url (relative to root)
        "content": "app/content/test.md" // .md or .html to render,
        "script": "js/script.js" // Optional, relative to the /public folder
        "options": { //Optional, passed directly to template rendering
          "suppressStructuredDataMarkup" : true // suppressed the ld+json block rendering
        }
      }
```