### PR TITLE
patch/paySwgVersion

### DIFF
--- a/app/content/add-swg-button.md
+++ b/app/content/add-swg-button.md
@@ -1,4 +1,5 @@
 <script async
+  subscriptions-control="manual"
   type="application/javascript"
   src="https://news.google.com/swg/js/v1/swg.js">
 </script>

--- a/app/content/add-swg-js.md
+++ b/app/content/add-swg-js.md
@@ -107,7 +107,7 @@ Read the [documentation](https://developers.google.com/news/subscribe/guides/add
     <script>
       (self.SWG = self.SWG || []).push( subscriptions => {
         // 3. Explicitly specify the Pay backend version to use
-        subscriptions.configure({paySwgVersion: '2'})
+        subscriptions.configure({paySwgVersion: '2'});
 
         // 4. Use a Publication ID (example.com) or a Product ID (example.com:premium)
         subscriptions.init(publicationOrProductId);

--- a/app/content/add-swg-js.md
+++ b/app/content/add-swg-js.md
@@ -97,15 +97,20 @@ Read the [documentation](https://developers.google.com/news/subscribe/guides/add
 ```html 
 <html>
   <head>
-    <!-- 1. Include the swg client -->
-    <script async type="application/javascript"
-            src="https://news.google.com/swg/js/v1/swg.js"></script>
+    <!-- 1. Include the swg client with the subscriptions-control attribute set to "manual" -->
+    <script async 
+      subscriptions-control="manual"
+      type="application/javascript"
+      src="https://news.google.com/swg/js/v1/swg.js"></script>
 
     <!-- 2. Add a client ready callback -->
     <script>
       (self.SWG = self.SWG || []).push( subscriptions => {
-         // 3. Use a Publication ID (example.com) or a Product ID (example.com:premium)
-         subscriptions.init(publicationOrProductId);
+        // 3. Explicitly specify the Pay backend version to use
+        subscriptions.configure({paySwgVersion: '2'})
+
+        // 4. Use a Publication ID (example.com) or a Product ID (example.com:premium)
+        subscriptions.init(publicationOrProductId);
       });
     </script>
   </head>

--- a/public/js/add-swg-button.js
+++ b/public/js/add-swg-button.js
@@ -31,8 +31,8 @@ function analyticsEventLogger(subs) {
   }
   
   (self.SWG = self.SWG || []).push(subscriptions => {
-    subscriptions.configure({paySwgVersion: '2'})
-    subscriptions.init('CAowqfCKCw')
+    subscriptions.configure({paySwgVersion: '2'});
+    subscriptions.init('CAowqfCKCw');
 
     analyticsEventLogger(subscriptions);
 

--- a/public/js/add-swg-button.js
+++ b/public/js/add-swg-button.js
@@ -35,9 +35,6 @@ function analyticsEventLogger(subs) {
     subscriptions.init('CAowqfCKCw')
 
     analyticsEventLogger(subscriptions);
-  
-    // subscriptions.start()
-    
 
     // 3. Render the smart button onto the DOM element
     let swgStdButton = document.getElementById('swg-standard-button');

--- a/public/js/add-swg-button.js
+++ b/public/js/add-swg-button.js
@@ -31,10 +31,14 @@ function analyticsEventLogger(subs) {
   }
   
   (self.SWG = self.SWG || []).push(subscriptions => {
+    subscriptions.configure({paySwgVersion: '2'})
+    subscriptions.init('CAowqfCKCw')
+
     analyticsEventLogger(subscriptions);
   
-    // subscriptions.start();
-  
+    // subscriptions.start()
+    
+
     // 3. Render the smart button onto the DOM element
     let swgStdButton = document.getElementById('swg-standard-button');
     subscriptions.attachButton(


### PR DESCRIPTION
This PR adds documentation and a functioning example of using `subscriptions.configure({paySwgVersion: '2'})` with manual initialization of `swg.js`.

> [!IMPORTANT]
> Using `paySwgVersion: '2'` is relevant only when initializing `swg.js` manually. See [initialization](https://reader-revenue-demo.ue.r.appspot.com/swg/add-swg-js) for more information.

## Example:

1. Include the `swg.js` library with `subscriptions-control="manual"` set to prevent automatic initialization.

```html
<script async
  subscriptions-control="manual"
  type="application/javascript"
  src="https://news.google.com/swg/js/v1/swg.js">
</script>
```
2. When initializing `swg.js`, use `paySwgVersion: '2'` to specify the updated backend configuration for handling purchases.

```javascript
(self.SWG = self.SWG || []).push(subscriptions => {
    subscriptions.configure({paySwgVersion: '2'})
    subscriptions.init(publicationId)
})
```

Prior art: [swg.js #3407](https://github.com/subscriptions-project/swg-js/pull/3407)

> [!NOTE]
> These changes can be viewed on the [beta add-button](https://beta-dot-reader-revenue-demo.ue.r.appspot.com/swg/add-button) instance, and will be available on the [prod add-button](https://reader-revenue-demo.ue.r.appspot.com/swg/add-button) instance after merging.