### PR TITLE
Added logging for Jwt identity response

### DIFF
--- a/public/js/publication-api-google-client.js
+++ b/public/js/publication-api-google-client.js
@@ -70,6 +70,8 @@ async function handleClientInitialization(response) {
   let parsedJwt = parseJwt(response.credential);
   let authorizationCode = getAuthzCred('authorizationCode');
 
+  console.log("handleClientInitialization Jwt returned", {parsedJwt});
+
   if (authorizationCode != null) {  // query directly the publication api
     console.log('AuthorizationCode found for this user in our systems.');
     // ensure it is still valid; refresh it otherwise


### PR DESCRIPTION
This PR logs to the console the full Jwt that is returned from the Sign in with Google flow in the Publication API example.