### PR TITLE
Added PAY_SWG_VERSION as a new env var, with supporting docs

### DIFF
--- a/app/content/overview.md
+++ b/app/content/overview.md
@@ -77,6 +77,11 @@ GTAG_DEBUG_MODE=true #Enable 'debug' mode in GA for streaming all events
 # Setting this change the 'swg.js' script tag to be 'swg-another-value.js'
 SWG_OVERRIDE=another-value 
 
+# By default, swg.js is initialized with subscriptions.configure({paySwgVersion:'2'})
+# For SwG Classic publications, set this optional variable to a different version
+PAY_SWG_VERSION='1' # For SwG Classic
+# PAY_SWG_VERSION='2' # For RRM:E, default value of this variable is ommitted
+
 # Prompt Configurations
 # This value is a stringified JSON configuration of the following schema:
 # { "TYPE_<prompt type>": [

--- a/lib/renderers.js
+++ b/lib/renderers.js
@@ -40,7 +40,8 @@ function safeEnvVars() {
     GTAG_DEBUG_MODE,
     PROMPT_CONFIG,
     PROMPT_CONFIG_BASE64,
-    SWG_OVERRIDE
+    SWG_OVERRIDE,
+    PAY_SWG_VERSION
   } = process.env;
       
   return {
@@ -53,7 +54,8 @@ function safeEnvVars() {
     GTAG_DEBUG_MODE,
     PROMPT_CONFIG,
     PROMPT_CONFIG_BASE64,
-    SWG_OVERRIDE
+    SWG_OVERRIDE,
+    PAY_SWG_VERSION
   };
 }
 

--- a/public/js/add-swg-button.js
+++ b/public/js/add-swg-button.js
@@ -31,7 +31,30 @@ function analyticsEventLogger(subs) {
   }
   
   (self.SWG = self.SWG || []).push(subscriptions => {
-    subscriptions.configure({paySwgVersion: '2'});
+
+ 
+    /*
+      Note: the process env variable is replaced when rendered for
+      client-side usage. If the env var PAY_SWG_VERSION is set to '1', the
+      following line would read something like:
+
+      const paySwgVersion = '1' == '1' ? '1' : '2'
+
+      This is because the renderStaticFile() method pre-processes .js files
+      on the server before sending them to the browser.
+
+      Because most uses of reader-revenue-demo are for RRM:E, if the 
+      env var PAY_SWG_VERSION is omitted, we set '2' to the default value.
+      If it is set explicitly to '1', the subscriptions.configure() function
+      does not execute.
+
+    */ 
+    const paySwgVersion = 'process.env.PAY_SWG_VERSION' == '1' ? '1' : '2'
+
+    //Only if the above evaluates to '2' do we use subscriptions.configure()
+    if (paySwgVersion == '2') {
+      subscriptions.configure({paySwgVersion: '2'});
+    }
     subscriptions.init('process.env.PUBLICATION_ID');
 
     analyticsEventLogger(subscriptions);


### PR DESCRIPTION
This PR allows for setting `paySwgVersion` for an instance of `reader-revenue-demo` for the buyflow example page. It does so by exposing a new safeEnvVar `PAY_SWG_VERSION`. If this is set to '1' explicitly, we can suppress the `subscriptions.configure()` call on the buyflow page. 

Note: There are two ways we could improve upon this.
1. Move this to a page-specific option, like how `suppressStructuredDataMarkup` works on a per-route level
2. Keep the implementation as is, but use the initialization logic to optionally suppress `subscriptions.configure()` from `add-swg-button.js` in other files that use `swg.js`.

This can be previewed on the bundling example sites:
- https://bundling-bar-dot-reader-revenue-demo.ue.r.appspot.com/swg/add-button
- https://bundling-foo-dot-reader-revenue-demo.ue.r.appspot.com/swg/add-button