### PR TITLE
Replacing an archived RRM:E sku with a live one

### DIFF
--- a/public/js/add-swg-button.js
+++ b/public/js/add-swg-button.js
@@ -80,7 +80,7 @@ function analyticsEventLogger(subs) {
         // showOffersor subscribe(SKU)
         function() {
           subscriptions.subscribe(
-              'SWGPD.1364-3969-4803-51719');  // Show offers carousel
+              'SWGPD.9393-6870-9481-85493');  // Show offers carousel
         });
   
   


### PR DESCRIPTION
At the moment, there's an error when you hit the offer button for a demo because the sku is currently archived.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/9dccf530-572e-47cb-93c4-0c8f3b73f927" />

This PR updates the archived sku with a live one so that the demo will restart working. 

<img width="600" alt="image" src="https://github.com/user-attachments/assets/19d49bec-52f7-4795-83d7-a4a7ff031705" />

staging is available at https://temp-dot-reader-revenue-demo.ue.r.appspot.com/swg/add-button#offerButton
