### PR TITLE
adding '_' to env vars - SWG_SKU & NEWSLETTER_CTA_CONFIGURATION_ID

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -38,8 +38,8 @@ steps:
         sed -i "s/##PUBLICATION_ID##/${_PUBLICATION_ID}/g" app.yaml
         sed -i "s/##CTA_CONFIG##/${_CTA_CONFIG}/g" app.yaml
         sed -i "s/##CTA_CONFIG_BASE64##/${_CTA_CONFIG_BASE64}/g" app.yaml
-        sed -i "s/##SWG_SKU##/${SWG_SKU}/g" app.yaml
-        sed -i "s/##NEWSLETTER_CTA_CONFIGURATION_ID##/${NEWSLETTER_CTA_CONFIGURATION_ID}/g" app.yaml
+        sed -i "s/##SWG_SKU##/${_SWG_SKU}/g" app.yaml
+        sed -i "s/##NEWSLETTER_CTA_CONFIGURATION_ID##/${_NEWSLETTER_CTA_CONFIGURATION_ID}/g" app.yaml
         gcloud config set app/cloud_build_timeout 1600
         gcloud app deploy
 timeout: 1600s


### PR DESCRIPTION
To solve this build error `Your build failed to run: generic::invalid_argument: invalid value for 'build.substitutions': key in the template "SWG_SKU" is not a valid built-in substitution`

internal note: b/371393858#comment5