### PR TITLE
Patch: Fix pub/sub v2 refresh checking

### DIFF
--- a/public/js/pub-sub.js
+++ b/public/js/pub-sub.js
@@ -31,10 +31,14 @@ async function pollNotifications(pubSubVersion) {
 
 function scheduleNotifications() {
   const pubSubVersions = ['v1','v2'];
-  let currentNotifications = '';
 
   // loop through each pubSubVersion
   pubSubVersions.forEach((pubSubVersion)=>{
+    
+    // CurrentNotifications will contain a stringified version of the current set of notifications
+    // which is used to prevent unnecessary DOM updates.
+    let currentNotifications = '';
+
     let emptyOutputPlaceHolder = null; 
     const loader = new Loader(
       document.getElementById(`notificationsLog-${pubSubVersion}`), 

--- a/public/js/pub-sub.js
+++ b/public/js/pub-sub.js
@@ -29,15 +29,18 @@ async function pollNotifications(pubSubVersion) {
       e => console.log(e));
 }
 
+function getMostRecentTimestamp(notifications) {
+  return notifications.pop().created
+}
+
 function scheduleNotifications() {
   const pubSubVersions = ['v1','v2'];
 
   // loop through each pubSubVersion
   pubSubVersions.forEach((pubSubVersion)=>{
-    
-    // CurrentNotifications will contain a stringified version of the current set of notifications
-    // which is used to prevent unnecessary DOM updates.
-    let currentNotifications = '';
+
+    // placeholder to hold most recent timestamp
+    let savedRecentTimestamp = 0
 
     let emptyOutputPlaceHolder = null; 
     const loader = new Loader(
@@ -55,8 +58,12 @@ function scheduleNotifications() {
     setInterval(async () => {
       // poll the backend for notifications for the current pubSubVersion.
       const notifications = await pollNotifications(pubSubVersion);
+
+      // find the created timestamp from the last notification
+      const mostRecentTimestamp = getMostRecentTimestamp(notifications);
+
       // check if notifications were received AND if they differ from the cached version.
-      if (notifications?.length > 0 && JSON.stringify(notifications) != currentNotifications) {
+      if (notifications?.length > 0 && savedRecentTimestamp != mostRecentTimestamp) {
         console.log(`new pub/sub messages, re-displaying for pubSubVersion ${pubSubVersion}`);
         // remove the placeholder output ([]) if it's already added  
         // emptyOutputPlaceHolder is non null if the loader's onTimeout callback is alraedy executed 
@@ -66,8 +73,10 @@ function scheduleNotifications() {
         }
         // display the new Pub/Sub notifications using syntax highlighting
         insertHighlightedJson(`#notificationsLog-${pubSubVersion}`, notifications, null, null, true);
-        // cache the current notifications to check and compare in the next interval
-        currentNotifications = JSON.stringify(notifications);
+        
+        // cache the current timestamp
+        savedRecentTimestamp = mostRecentTimestamp;
+
         // stop the loading indicator now that content is displayed.
         if(loader.isStopped===false) {
           loader.stop();


### PR DESCRIPTION
This PR does two things to improve the performance of notification update checking:

1. Moves the placeholder for recent notifications to within the refresh loop.
2. Changes the comparison method to store and compare against the most recent `created` timestamp from the last notification, rather than compare a stringified version of all notifications.

Long term, this could be improved by creating a new endpoint that just surfaces the most recent timestamp, as it is still inefficient to return all notifications every time, but this is a good start.